### PR TITLE
Add structured documentation for ms2Gauss pipeline

### DIFF
--- a/documentation/Agents.md
+++ b/documentation/Agents.md
@@ -1,0 +1,59 @@
+---
+title: Codex Agents for ms2Gauss
+kind: meta
+source: documentation/Agents.md
+last_updated: 2025-02-14
+---
+
+# Codex Agents Configuration for the ms2Gauss Repository
+
+This file routes every request to the correct **mode** (Documentation, Analysis, Planning, Concept, Refactor) while enforcing the scientific context and the requirements described in [`Prompt_CodexDocumentation.md`](../Prompt_CodexDocumentation.md).
+
+## 1. Global principles
+
+1. **Protect scientific intent.** Every change must honor the Orbitrap MS2-first, Gaussian modeling workflow described in the ms2Gauss draft and references.
+2. **Obey the documentation prompt.** Use [`DocumentationTemplate.md`](../DocumentationTemplate.md) semantics, metadata headers, cross-linking, math notes, plots, and table examples.
+3. **Prefer Python for figures.** Code snippets that illustrate peaks, chromatograms, or networks should rely on numpy + matplotlib.
+4. **Keep links alive.** Any object that is mentioned must link to its markdown doc; missing docs require stubs that clearly say so.
+5. **No silent refactors.** Do not alter behavior unless a task explicitly requires it, and explain any numerical implications.
+
+## 2. Mode reference
+
+| Mode | When to use | Key responsibilities |
+| --- | --- | --- |
+| DocumentationAgent | New or updated docs, glossaries, theory chapters, or figure instructions. | Follow the full prompt, expand coverage to all functions/variables/tables, add math notes, Python examples, and figures. |
+| AnalysisAgent | User asks to run workflows, produce exploratory plots, or demonstrate usage. | Build runnable examples referencing repo functions and variables; keep outputs MS2-first. |
+| PlanningAgent | User needs a roadmap or improvement strategy. | Update [`documentation/IMPROVEMENT_PLAN.md`](./IMPROVEMENT_PLAN.md) and outline actionable steps linked to functions/variables. |
+| RefactorAgent | Code structure or performance improvements are explicitly requested. | Preserve semantics, cite affected files, and synchronize docs. |
+| ConceptAgent | Pure explanations of ms2Gauss concepts. | Lean on [`documentation/DEFINITIONS.md`](./DEFINITIONS.md) and [`documentation/GLOSSARY.md`](./GLOSSARY.md), including LaTeX where needed. |
+
+## 3. Mode selection checklist
+
+1. Parse the user request and determine whether it is documentation-, analysis-, planning-, refactor-, or concept-focused.
+2. Adopt the matching mode (or combination) internally and follow its guardrails.
+3. Always apply the global principles above plus any nested instructions from directory-level `AGENTS.md` files (currently only this file).
+
+## 4. Documentation-specific guardrails
+
+- Generate a **plan-first** response when explicitly requested before writing docs.
+- Every new doc must start with the metadata header defined above.
+- Each function doc must include: description with scientific context, math notes (if non-trivial), verbatim code block, key operations bullets, parameter descriptions, input/output links, helper-function links, “Called by” links, and an `Examples` section with runnable Python showing realistic data and at least one matplotlib visualization snippet.
+- Each variable/table doc must include a physical description, snippet showing how it is defined (code or representative rows), key operations, per-column meaning, an example table with real units, and references to producer/consumer functions.
+
+## 5. Analysis and plotting rules
+
+- Prefer simulated but realistic Orbitrap-like data when real files are unavailable.
+- Show how to build `numpy` arrays that mimic m/z or RT axes and how Gaussian parameters map to physical quantities.
+- When illustrating redundancy or alignment, use scatter/heatmap plots with annotated tolerances.
+
+## 6. Improvement planning rules
+
+- Separate conceptual vs computational vs missing-function recommendations.
+- Tie each recommendation to specific docs or source files so future contributors can act quickly.
+
+## 7. Concept explanations
+
+- Cross-link to glossary entries such as [m/z](./GLOSSARY.md#mz), [spectral redundancy](./DEFINITIONS.md#spectral-redundancy), or [Gaussian peak](./DEFINITIONS.md#gaussian-peak) whenever those ideas appear.
+- Include LaTeX for mass error, Gaussian models, or similarity scores, and cite supporting references from `/references` when possible.
+
+Following this routing document keeps every ms2Gauss change coherent, reproducible, and scientifically faithful.

--- a/documentation/DEFINITIONS.md
+++ b/documentation/DEFINITIONS.md
@@ -1,0 +1,71 @@
+---
+title: ms2Gauss Theoretical Definitions
+kind: meta
+source: documentation/DEFINITIONS.md
+last_updated: 2025-02-14
+---
+
+# ms2Gauss Theory and Data Structures
+
+This chapter consolidates the physics, statistics, and data structures that appear across ms2Gauss documentation. Use it together with the [Glossary](./GLOSSARY.md) and individual function/variable pages.
+
+## Orbitrap signal formation
+
+Orbitrap instruments capture ion image currents and resolve them via Fourier transform. The resulting profile spectra have ppm-level mass accuracy, enabling Gaussian modeling of each peak. Functions such as [`AllMS2Data`](./Functions/AllMS2Data.md) and [`ms2_spectrum`](./Functions/ms2_spectrum.md) assume profile-mode arrays with columns `[m/z, intensity]`.
+
+## Gaussian peak model {#gaussian-peak}
+
+ms2Gauss represents both MS1 and MS2 peaks as normal distributions parameterized by centroid \(\mu\), standard deviation \(\sigma\), and total integrated intensity \(I_{\text{total}}\):
+\[
+I(m/z) = \frac{I_{\text{total}}}{\sigma\sqrt{2\pi}} \exp\left[-\frac{(m/z-\mu)^2}{2\sigma^2}\right]
+\]
+[`GaussianPeak`](./Functions/GaussianPeak.md) implements this expression. Curve fitting performed in [`Normal_Fit`](./Functions/Normal_Fit.md) refines \(\mu\) and \(\sigma\) for MS1 peaks associated with MS2 features.
+
+## Confidence intervals and ppm error
+
+[`ms2_features_stats`](./Functions/ms2_features_stats.md) propagates uncertainty using Student’s t-distribution:
+\[
+\text{CI}_{\text{Da}} = t_{1-\alpha,\,N-1} \frac{\sigma}{\sqrt{N}}, \quad
+\text{CI}_{\text{ppm}} = 10^6 \frac{\text{CI}_{\text{Da}}}{m/z}
+\]
+These columns appear in [`MS2_Features`](./Variables/MS2_Features.md) and downstream alignment tables.
+
+## Spectral redundancy {#spectral-redundancy}
+
+Multiple MS2 scans may target the same precursor. [`ms2_SpectralRedundancy`](./Functions/ms2_SpectralRedundancy.md) reads summary spreadsheets, filters them by RT/m/z, and clusters spectra via cosine similarity from [`ms2_SpectralSimilarityClustering`](./Functions/ms2_SpectralSimilarityClustering.md). Cluster statistics (min/max RT, number of spectra, representative spectrum ID) populate [`SummMS2`](./Variables/SummMS2.md).
+
+## MS2-first feature construction
+
+1. [`AllMS2Data`](./Functions/AllMS2Data.md) extracts MS2 detections into `SummMS2` when only raw profile data are available.
+2. [`ms2_spectrum`](./Functions/ms2_spectrum.md) builds clean fragment lists from raw spectra using [`ms2_peakStats_safe`](./Functions/ms2_peakStats_safe.md).
+3. [`ms2_features_stats`](./Functions/ms2_features_stats.md) links each MS2 detection to MS1 chromatograms via [`closest_ms1_spec`](./Functions/closest_ms1_spec.md) and Gaussian fits.
+4. [`feat_ms2_Gauss`](./Functions/feat_ms2_Gauss.md) aggregates these per-MS2 fits into [`MS2_Features`](./Variables/MS2_Features.md).
+5. [`Features_ms2_SamplesAligment`](./Functions/Features_ms2_SamplesAligment.md) merges per-sample feature tables into [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md).
+
+## Chromatographic umbrellas and alignment
+
+Chromatographic umbrellas are defined by `min_RT`/`max_RT` windows in `SummMS2` and copied to `MS2_Features`. During alignment, these umbrellas anchor sample-specific intensities and retention times in `[AlignedSamplesDF, AlignedSamples_RT_DF]`. Tolerances `RT_tol` and `mz_Tol` govern clustering decisions.
+
+## Genetic algorithms for chromatograms
+
+Several modules (e.g., `ResolvingChromatogram`, `MutateParameters`, `EvaluatePopulation`) use genetic algorithms to deconvolve overlapping Gaussian RT profiles. Populations encode sets of Gaussian parameters; crossover/mutation operations explore parameter space; fitness evaluates r² or residual error against experimental chromatograms. While not fully documented here, these functions inherit the Gaussian model defined above.
+
+## Data tables
+
+- [`SummMS2`](./Variables/SummMS2.md): per-cluster MS2 metadata (centroid m/z, RT, MS2 IDs, umbrella bounds).
+- [`MS2_Features`](./Variables/MS2_Features.md): MS1-refined precursor statistics tied to MS2 provenance.
+- [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md): feature-by-sample matrix storing aligned intensities and umbrella metadata.
+- [`AlignedSamples_RT_DF`](./Variables/AlignedSamples_RT_DF.md): same layout but retaining RT for each sample slot.
+- [`All_FeaturesTable`](./Variables/All_FeaturesTable.md): concatenation of per-sample feature tables before alignment.
+
+## Similarity measures
+
+Cosine similarity for fragment vectors \(\vec{a}, \vec{b}\):
+\[
+\cos(\theta) = \frac{\vec{a}\cdot\vec{b}}{\|\vec{a}\|\,\|\vec{b}\|}
+\]
+Used in `ms2_SpectralSimilarityClustering` to create adjacency matrices. Alternative metrics (Tanimoto) appear in other clustering modules.
+
+## References
+
+Concepts summarized here draw from the ms2Gauss draft (references/draft.pdf) and Orbitrap-focused MS2 feature modeling literature such as Hu et al., Anal. Chem. (2020) on MS2-first workflows.

--- a/documentation/Functions/AdjacencyClustering.md
+++ b/documentation/Functions/AdjacencyClustering.md
@@ -1,0 +1,50 @@
+---
+title: AdjacencyClustering
+kind: function
+source: Functions/AdjacencyClustering.py
+last_updated: 2025-02-14
+---
+
+## Description
+`AdjacencyClustering` performs a depth-first traversal of an adjacency list to collect all vertices reachable from a seed feature. It underpins module formation in [`ms2_feat_modules`](./ms2_feat_modules.md).
+
+## Code
+```python
+import numpy as np
+def AdjacencyClustering(ms2_id,AdjacencyList,Module=[]):
+    CurrentModule=set(AdjacencyList[ms2_id])
+    CurrentModule=CurrentModule-set(Module)
+    Module=Module+list(CurrentModule)
+    for ms2_id in CurrentModule:
+        Module=AdjacencyClustering(ms2_id=ms2_id,AdjacencyList=AdjacencyList,Module=Module)
+    return Module
+```
+
+## Key operations
+- Recursively visits neighbors, ensuring each node is processed once.
+- Accumulates nodes into `Module` and returns the complete connected component.
+
+## Parameters
+- `ms2_id (int)`: starting vertex.
+- `AdjacencyList (list)`: neighbors per feature.
+- `Module (list)`: accumulator (default empty).
+
+## Input
+- Called internally by [`ms2_feat_modules`](./ms2_feat_modules.md).
+
+## Output
+- List of indices belonging to the connected component.
+
+## Functions
+- Uses recursion only.
+
+## Called by
+- [`ms2_feat_modules`](./ms2_feat_modules.md)
+
+## Examples
+```python
+AdjacencyList = [[0,1], [0,1], [2]]
+from Functions.AdjacencyClustering import AdjacencyClustering
+module = AdjacencyClustering(0, AdjacencyList, Module=[0])
+print(module)
+```

--- a/documentation/Functions/AdjacencyListFeatures.md
+++ b/documentation/Functions/AdjacencyListFeatures.md
@@ -1,0 +1,90 @@
+---
+title: AdjacencyListFeatures
+kind: function
+source: Functions/AdjacencyListFeatures.py
+last_updated: 2025-02-14
+---
+
+## Description
+`AdjacencyListFeatures` builds RT/m/z neighborhood lists for MS2 features. Each feature’s m/z confidence interval and RT umbrella are compared against every other feature to determine potential matches. The result drives graph-based clustering in [`ms2_feat_modules`](./ms2_feat_modules.md), [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md), and [`Cluster_ms2_Features`](./Cluster_ms2_Features.md).
+
+## Code
+```python
+import numpy as np
+def AdjacencyListFeatures(MS2_features,mz_col=3,mz_CI_col=8,RT_col=2,minRT_col=12,maxRT_col=13,RT_tol=0,mz_Tol=0):
+    N_possible_feat=len(MS2_features[:,0])
+    if mz_Tol==0:
+        mz_CI_Vec=MS2_features[:,mz_CI_col]
+    else:
+        mz_CI_Vec=np.ones(N_possible_feat)*mz_Tol
+    mzVec=MS2_features[:,mz_col]
+    mzMaxVec=mzVec+mz_CI_Vec
+    mzMinVec=mzVec-mz_CI_Vec
+    if RT_tol==0:
+        RTMaxVec=MS2_features[:,maxRT_col]
+        RTMinVec=MS2_features[:,minRT_col]
+    else:
+        RTMaxVec=MS2_features[:,RT_col]+RT_tol
+        RTMinVec=MS2_features[:,RT_col]-RT_tol
+    AdjacencyList=[]
+    feat_ids=[]
+    for feat_id in np.arange(N_possible_feat):
+        min_mz=mzMinVec[feat_id]
+        max_mz=mzMaxVec[feat_id]
+        min_RT=RTMinVec[feat_id]
+        max_RT=RTMaxVec[feat_id]
+        NearFilter=(mzMaxVec>=min_mz)&(mzMinVec<=max_mz)&(RTMaxVec>=min_RT)&(RTMinVec<=max_RT)
+        Neigbours=np.where(NearFilter)[0]
+        AdjacencyList.append(Neigbours)
+        if len(Neigbours)>0:
+            feat_ids.append(feat_id)
+    feat_ids=set(feat_ids)
+    return [AdjacencyList,feat_ids]
+```
+
+## Key operations
+- Derives m/z bounds from either the per-feature CI (`mz_CI_col`) or a fixed tolerance `mz_Tol`.
+- Derives RT bounds from umbrella columns or ±`RT_tol` windows.
+- Marks neighbors when intervals overlap in both dimensions.
+
+## Parameters
+- `MS2_features (np.ndarray)`: typically [`MS2_Features`](../Variables/MS2_Features.md) or [`All_FeaturesTable`](../Variables/All_FeaturesTable.md).
+- `mz_col`, `mz_CI_col`, `RT_col`, `minRT_col`, `maxRT_col`: column indices.
+- `RT_tol`, `mz_Tol`: override tolerances.
+
+## Input
+- Passed arrays from feature tables.
+
+## Output
+- `AdjacencyList`: list of numpy index arrays.
+- `feat_ids`: set of features having at least one neighbor.
+
+## Functions
+- Uses numpy only.
+
+## Called by
+- [`ms2_feat_modules`](./ms2_feat_modules.md)
+- [`Cluster_ms2_Features`](./Cluster_ms2_Features.md)
+- [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md)
+
+## Examples
+```python
+import numpy as np
+from Functions.AdjacencyListFeatures import AdjacencyListFeatures
+
+features = np.array([
+    [0,0,245.0,300.123,0,0,0,0,1e-4,0,0,0,240,248],
+    [0,0,246.0,300.124,0,0,0,0,1e-4,0,0,0,241,249]
+])
+AdjList, ids = AdjacencyListFeatures(features, mz_col=3, mz_CI_col=8, RT_col=2)
+print(ids)
+```
+Plotting adjacency density:
+```python
+import matplotlib.pyplot as plt
+neighbor_counts = [len(nei) for nei in AdjList]
+plt.bar(range(len(neighbor_counts)), neighbor_counts)
+plt.xlabel('Feature index')
+plt.ylabel('# neighbors')
+plt.show()
+```

--- a/documentation/Functions/AdjacencyList_from_matrix.md
+++ b/documentation/Functions/AdjacencyList_from_matrix.md
@@ -1,0 +1,36 @@
+---
+title: AdjacencyList_from_matrix
+kind: function
+source: Functions/AdjacencyList_from_matrix.py
+last_updated: 2025-02-14
+---
+
+## Description
+Transforms a similarity matrix (e.g., cosine scores) into an adjacency list by thresholding entries above `minAdjacency`. Used to build graph representations for clustering.
+
+## Code
+```python
+import numpy as np
+def AdjacencyList_from_matrix(AdjacencyMatrix,N_ms2_spectra,minAdjacency=0):
+    AdjacencyList=[]
+    ms2_ids=[]
+    for ms2_candidate_id in np.arange(N_ms2_spectra,dtype='int'):
+        Neigbours=np.where(AdjacencyMatrix[ms2_candidate_id,:]>minAdjacency)[0]
+        if len(Neigbours)>0:
+            ms2_ids.append(ms2_candidate_id)
+        AdjacencyList.append(Neigbours)
+    ms2_ids=set(ms2_ids)
+    return [AdjacencyList,ms2_ids]
+```
+
+## Output
+- `AdjacencyList`: list of neighbor indices.
+- `ms2_ids`: set of vertices with at least one neighbor.
+
+## Called by
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Example
+```python
+AdjList, ids = AdjacencyList_from_matrix(CosineMat, N_ms2_spectra=len(CosineMat), minAdjacency=0.9)
+```

--- a/documentation/Functions/AdjacencyList_ms2Fragments.md
+++ b/documentation/Functions/AdjacencyList_ms2Fragments.md
@@ -1,0 +1,50 @@
+---
+title: AdjacencyList_ms2Fragments
+kind: function
+source: Functions/AdjacencyList_ms2Fragments.py
+last_updated: 2025-02-14
+---
+
+## Description
+Builds adjacency lists for aligned MS2 fragments. Two fragments are considered neighbors when their m/z windows overlap. The output guides fragment clustering prior to cosine similarity calculations.
+
+## Code
+```python
+import numpy as np
+def AdjacencyList_ms2Fragments(All_ms2):
+    N_fragments=len(All_ms2[:,0])
+    mzMaxVec=All_ms2[:,0]+All_ms2[:,5]
+    mzMinVec=All_ms2[:,0]-All_ms2[:,5]
+    AdjacencyList=[]
+    frag_ids=[]
+    for feat_id in np.arange(N_fragments):
+        mz=All_ms2[feat_id,0]
+        mz_CI=All_ms2[feat_id,5]
+        min_mz=mz-mz_CI
+        max_mz=mz+mz_CI
+        NearFilter=(mzMaxVec>min_mz)&(mzMinVec<max_mz)
+        Neigbours=np.where(NearFilter)[0]
+        AdjacencyList.append(Neigbours)
+        if len(Neigbours)>0:
+            frag_ids.append(feat_id)
+    frag_ids=set(frag_ids)
+    return [AdjacencyList,frag_ids]
+```
+
+## Key operations
+- Computes dynamic m/z bounds per fragment using column 5 (`mz_CI`).
+- Marks neighbors when intervals overlap.
+
+## Parameters
+- `All_ms2`: array returned by [`Retrieve_and_Join_ms2_for_feature`](./Retrieve_and_Join_ms2_for_feature.md).
+
+## Output
+- `AdjacencyList`, `frag_ids`
+
+## Called by
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Example
+```python
+AdjList, ids = AdjacencyList_ms2Fragments(All_ms2)
+```

--- a/documentation/Functions/AligniningFragments_in_Feature.md
+++ b/documentation/Functions/AligniningFragments_in_Feature.md
@@ -1,0 +1,49 @@
+---
+title: AligniningFragments_in_Feature
+kind: function
+source: Functions/AligniningFragments_in_Feature.py
+last_updated: 2025-02-14
+---
+
+## Description
+Aligns fragment modules into a matrix where rows represent aligned fragment groups and columns represent features within the module. Column 0 stores the fragment m/z, while subsequent columns store relative intensities for each feature. The matrix is used by [`CosineMatrix`](./CosineMatrix.md).
+
+## Code
+```python
+import numpy as np
+def AligniningFragments_in_Feature(Frag_Modules,All_ms2,N_features):
+    N_Fragments=len(Frag_Modules)
+    AlignedFragmentsMat=np.zeros((N_Fragments,N_features+1))
+    for fragment_id in np.arange(N_Fragments,dtype='int'):
+        Fragment_module=Frag_Modules[fragment_id]
+        FragmentTable=All_ms2[Fragment_module,:]
+        MaxInt=np.max(FragmentTable[:,2])
+        MaxInt_Loc=np.where(FragmentTable[:,2]==MaxInt)[0]
+        AlignedFragmentsMat[fragment_id,0]=FragmentTable[MaxInt_Loc,0]
+        Fragments_ids=np.array(FragmentTable[:,10],dtype='int')
+        AlignedFragmentsMat_loc=Fragments_ids+1
+        AlignedFragmentsMat[fragment_id,AlignedFragmentsMat_loc]=FragmentTable[:,9]
+    AlignedFragmentsMat=AlignedFragmentsMat[AlignedFragmentsMat[:,0].argsort()]
+    return AlignedFragmentsMat
+```
+
+## Key operations
+- For each fragment module, finds the m/z of the most intense instance and stores it in column 0.
+- Places relative intensities (column 9 of `All_ms2`) into feature-specific columns using the stored feature IDs (column 10).
+- Sorts rows by m/z to ease visualization.
+
+## Parameters
+- `Frag_Modules`: list of fragment index arrays from [`ms2_feat_modules`](./ms2_feat_modules.md).
+- `All_ms2`: concatenated fragment array.
+- `N_features`: number of features being compared.
+
+## Output
+- `AlignedFragmentsMat`: matrix consumed by [`CosineMatrix`](./CosineMatrix.md).
+
+## Called by
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Example
+```python
+AlignedFragmentsMat = AligniningFragments_in_Feature(Frag_Modules, All_ms2, N_features=len(Feature_module))
+```

--- a/documentation/Functions/AllMS2Data.md
+++ b/documentation/Functions/AllMS2Data.md
@@ -1,0 +1,83 @@
+---
+title: AllMS2Data
+kind: function
+source: Functions/AllMS2Data.py
+last_updated: 2025-02-14
+---
+
+## Description
+`AllMS2Data` streams every spectrum in a `DataSet`, keeps only MS2 scans that fall within user-defined m/z and RT windows, and summarizes them into [`SummMS2`](../Variables/SummMS2.md). Each accepted spectrum is routed through [`mz_RT_spectrum_filter`](./mz_RT_spectrum_filter.md), which reports precursor m/z, RT, total intensity, and diagnostic ratios. The resulting array is sorted by m/z to support reproducible downstream clustering.
+
+**Math notes**  
+Filtering occurs in two dimensions: RT is constrained by `min_RT ≤ RT ≤ max_RT`, while m/z is constrained by `min_mz ≤ precursor_mz ≤ max_mz`. Summed intensities provide the total ion current for each spectrum, and `maxInt_frac = I_{\text{max}} / \sum I` offers a quick check on spectral concentration.
+
+## Code
+```python
+import numpy as np
+from mz_RT_spectrum_filter import *
+def AllMS2Data(DataSet,min_RT=0,max_RT=1e5,min_mz=0,max_mz=1e4):
+    SummMS2=[]
+    FirstSpec=True
+    spectrum_id=0
+    for SpectralSignals in DataSet:
+        SummMS2=mz_RT_spectrum_filter(SpectralSignals=SpectralSignals,SummMS2=SummMS2,min_RT=min_RT,max_RT=max_RT,min_mz=min_mz,max_mz=max_mz,spectrum_id=spectrum_id)
+        spectrum_id+=1
+    SummMS2=np.array(SummMS2)
+    SummMS2=SummMS2[SummMS2[:,0].argsort(),:]
+    return SummMS2
+```
+
+## Key operations
+- Iterates once over `DataSet`, so memory footprint stays low even for large RAW files.
+- Delegates RT/mz filtering to [`mz_RT_spectrum_filter`](./mz_RT_spectrum_filter.md), which inspects MS level and precursor metadata.
+- Converts the Python list into a numpy array and sorts by `SummMS2[:,0]` (precursor m/z) for deterministic downstream behavior.
+
+## Parameters
+- `DataSet (iterable)`: Source of spectra, see [`DataSet`](../Variables/DataSet.md).
+- `min_RT`, `max_RT` (float, seconds): Retention-time bounds for accepted MS2 events.
+- `min_mz`, `max_mz` (float, Da): Mass bounds used to focus on relevant precursors.
+
+## Input
+- [`DataSet`](../Variables/DataSet.md): provides `SpectralSignals` objects.
+
+## Output
+- [`SummMS2`](../Variables/SummMS2.md): redundancy-aware MS2 summary table ready for MS2-first modeling.
+
+## Functions
+- [`mz_RT_spectrum_filter`](./mz_RT_spectrum_filter.md): inspects and appends eligible MS2 spectra.
+
+## Called by
+- Workflow notebooks (e.g., `feat.-ms2-Gauss.ipynb`) before executing [`ms2_spectrum`](./ms2_spectrum.md) or [`ms2_SpectralRedundancy`](./ms2_SpectralRedundancy.md).
+
+## Examples
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from Functions.AllMS2Data import AllMS2Data
+
+class MockSpectrum:
+    def __init__(self, level, rt, precursor_mz, peaks):
+        self._level, self._rt, self._precursor_mz, self._peaks = level, rt, precursor_mz, peaks
+    def getMSLevel(self):
+        return self._level
+    def getRT(self):
+        return self._rt
+    def getPrecursors(self):
+        return [type('P', (), {'getMZ': lambda self: self})(self._precursor_mz)]
+    def get_peaks(self):
+        return self._peaks
+
+spectra = [
+    MockSpectrum(2, 120.5, 300.12, [[300.12, 5e4], [310.00, 1e3]]),
+    MockSpectrum(1, 120.7, None, [[300.10, 1e5]]),
+    MockSpectrum(2, 500.0, 450.20, [[450.20, 8e4], [460.0, 5e3]])
+]
+SummMS2 = AllMS2Data(spectra, min_RT=100, max_RT=600, min_mz=250, max_mz=500)
+
+plt.scatter(SummMS2[:,1], SummMS2[:,0], s=50)
+plt.xlabel('RT (s)')
+plt.ylabel('Precursor m/z (Da)')
+plt.title('Accepted MS2 events')
+plt.show()
+```
+The scatter plot reveals which precursors passed the RT/m/z filters.

--- a/documentation/Functions/Cluster_ms2_Features.md
+++ b/documentation/Functions/Cluster_ms2_Features.md
@@ -1,0 +1,94 @@
+---
+title: Cluster_ms2_Features
+kind: function
+source: Functions/Cluster_ms2_Features.py
+last_updated: 2025-02-14
+---
+
+## Description
+`Cluster_ms2_Features` takes the raw [`MS2_Features`](../Variables/MS2_Features.md) array, builds adjacency relationships via [`AdjacencyListFeatures`](./AdjacencyListFeatures.md), groups them with [`ms2_feat_modules`](./ms2_feat_modules.md), and collapses each module into a representative feature. It outputs a pandas DataFrame with averaged metadata (mz, RT, uncertainties) and aggregated umbrella statistics.
+
+## Code
+```python
+import numpy as np
+import pandas as pd
+from ms2_feat_modules import *
+from AdjacencyListFeatures import *
+def Cluster_ms2_Features(MS2_features):
+    AdjacencyList,feat_ids=AdjacencyListFeatures(MS2_features=MS2_features)
+    Modules=ms2_feat_modules(AdjacencyList=AdjacencyList,ms2_ids=feat_ids)
+    ms2_FeaturesTable=[]
+    for mod in Modules:
+        MS2_feature=MS2_features[mod,:].copy()
+        MS2_feature=MS2_feature[(-MS2_feature[:,5]).argsort(),:]
+        min_RT=np.min(MS2_feature[:,12])
+        max_RT=np.max(MS2_feature[:,13])
+        N_spec=np.sum(MS2_feature[:,14])
+        MS2_feature[0,12]=np.max([min_RT,0])
+        MS2_feature[0,13]=max_RT
+        MS2_feature[0,14]=N_spec
+        ms2_FeaturesTable.append(MS2_feature[0,:])
+    ms2_FeaturesTable=np.array(ms2_FeaturesTable)
+    ms2_FeaturesTable=ms2_FeaturesTable[ms2_FeaturesTable[:,3].argsort(),:]
+    FeaturesColumns=["ms2_id",
+                "ms1_id",
+                "RT_(s)",
+                "mz_(Da)",
+                "mz_std_(Da)",
+                "I_tol_1spec",
+                "Gauss_r2",
+                "N_points_1spec",
+                "ConfidenceInterval_(Da)",
+                "ConfidenceInterval_(ppm)",
+                "min_mz_(Da)",
+                "max_mz_(Da)",
+                "min_RT_(s)",
+               "max_RT_(s)",
+               "N_ms2_spec",
+                "spectra_id"]
+    ms2_FeaturesDF=pd.DataFrame(ms2_FeaturesTable,columns=FeaturesColumns)
+    return ms2_FeaturesDF
+```
+
+## Key operations
+- Builds connectivity between features that share similar m/z/RT to reduce redundancy beyond single samples.
+- Within each module, sorts rows by intensity (column 5) descending and takes the top row as representative.
+- Updates umbrella statistics (min/max RT, total N_ms2_spec) to reflect the entire module.
+- Converts numpy array to pandas DataFrame with descriptive column names for easier export.
+
+## Parameters
+- `MS2_features (np.ndarray)`: output of [`feat_ms2_Gauss`](./feat_ms2_Gauss.md).
+
+## Input
+- [`MS2_Features`](../Variables/MS2_Features.md)
+
+## Output
+- pandas DataFrame `ms2_FeaturesDF` ready for writing to Excel or aligning across samples.
+
+## Functions
+- [`AdjacencyListFeatures`](./AdjacencyListFeatures.md)
+- [`ms2_feat_modules`](./ms2_feat_modules.md)
+
+## Called by
+- Commented hook inside [`feat_ms2_Gauss`](./feat_ms2_Gauss.md) and future workflows needing post-processing clusters.
+
+## Examples
+```python
+import numpy as np
+from Functions.Cluster_ms2_Features import Cluster_ms2_Features
+
+MS2_features = np.array([
+    [18240, 10021, 245.6, 300.1234, 1.5e-03, 8.2e05, 0.997, 28, 1.2e-04, 0.40, 299.118, 301.129, 240.1, 248.3, 3, 7021],
+    [18241, 10022, 245.8, 300.1235, 1.4e-03, 7.9e05, 0.995, 26, 1.3e-04, 0.43, 299.119, 301.130, 240.5, 248.5, 2, 7022]
+])
+ms2_df = Cluster_ms2_Features(MS2_features)
+print(ms2_df.head())
+```
+Plot aggregated intensities:
+```python
+import matplotlib.pyplot as plt
+plt.bar(ms2_df['ms2_id'], ms2_df['I_tol_1spec'])
+plt.xlabel('Representative ms2_id')
+plt.ylabel('Intensity (a.u.)')
+plt.show()
+```

--- a/documentation/Functions/CosineMatrix.md
+++ b/documentation/Functions/CosineMatrix.md
@@ -1,0 +1,43 @@
+---
+title: CosineMatrix
+kind: function
+source: Functions/CosineMatrix.py
+last_updated: 2025-02-14
+---
+
+## Description
+`CosineMatrix` computes pairwise cosine similarities between aligned fragment intensity vectors. It iterates over feature pairs, extracts the relevant columns from `AlignedFragmentsMat`, and delegates the computation to [`Cosine_2VecSpec`](./Cosine_2VecSpec.md).
+
+## Code
+```python
+import numpy as np
+from Cosine_2VecSpec import *
+def CosineMatrix(AlignedFragmentsMat,N_features):
+    CosineMat=np.zeros((N_features,N_features))
+    for feature_id1 in np.arange(N_features,dtype='int'):
+        for feature_id2 in np.arange(feature_id1,N_features,dtype='int'):
+            AlignedSpecMat=AlignedFragmentsMat[:,[0,feature_id1+1,feature_id2+1]]
+            Cosine=Cosine_2VecSpec(AlignedSpecMat=AlignedSpecMat)
+            CosineMat[feature_id1,feature_id2]=Cosine
+            CosineMat[feature_id2,feature_id1]=Cosine
+    return CosineMat
+```
+
+## Key operations
+- Builds symmetric cosine matrix by reusing computed values.
+- `AlignedSpecMat` stores fragment m/z plus two intensity columns, which [`Cosine_2VecSpec`](./Cosine_2VecSpec.md) interprets as aligned spectra.
+
+## Parameters
+- `AlignedFragmentsMat`: output from [`AligniningFragments_in_Feature`](./AligniningFragments_in_Feature.md).
+- `N_features`: number of aligned features.
+
+## Output
+- `CosineMat`: NxN similarity matrix.
+
+## Called by
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Example
+```python
+CosineMat = CosineMatrix(AlignedFragmentsMat, N_features)
+```

--- a/documentation/Functions/Cosine_2VecSpec.md
+++ b/documentation/Functions/Cosine_2VecSpec.md
@@ -1,0 +1,42 @@
+---
+title: Cosine_2VecSpec
+kind: function
+source: Functions/Cosine_2VecSpec.py
+last_updated: 2025-02-14
+---
+
+## Description
+Computes cosine similarity between two aligned MS2 spectra represented as column vectors. Used inside [`CosineMatrix`](./CosineMatrix.md).
+
+## Code
+```python
+import numpy as np
+def Cosine_2VecSpec(AlignedSpecMat):
+    S1_dot_S2=np.sum(AlignedSpecMat[:,1]*AlignedSpecMat[:,2])
+    S1_dot_S1=np.sum(AlignedSpecMat[:,1]*AlignedSpecMat[:,1])
+    S2_dot_S2=np.sum(AlignedSpecMat[:,2]*AlignedSpecMat[:,2])
+    dotXdot=S1_dot_S1*S2_dot_S2
+    if dotXdot==0:
+        return 0
+    Cosine=S1_dot_S2/np.sqrt(dotXdot)
+    return Cosine
+```
+
+## Key operations
+- Computes dot products and normalizes to produce cosine similarity.
+- Handles zero vectors by returning 0 to avoid division-by-zero.
+
+## Parameters
+- `AlignedSpecMat`: matrix with fragment m/z in column 0 and intensity vectors in columns 1–2.
+
+## Output
+- Cosine similarity scalar.
+
+## Called by
+- [`CosineMatrix`](./CosineMatrix.md)
+
+## Example
+```python
+AlignedSpecMat = np.array([[100, 0.8, 0.7], [110, 0.2, 0.3]])
+print(Cosine_2VecSpec(AlignedSpecMat))
+```

--- a/documentation/Functions/Features_ms2_SamplesAligment.md
+++ b/documentation/Functions/Features_ms2_SamplesAligment.md
@@ -1,0 +1,105 @@
+---
+title: Features_ms2_SamplesAligment
+kind: function
+source: Functions/Features_ms2_SamplesAligment.py
+last_updated: 2025-02-14
+---
+
+## Description
+`Features_ms2_SamplesAligment` merges feature tables from multiple samples, clusters them via [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md), and produces aligned matrices containing consensus metadata plus per-sample intensities and RTs. The function returns [`AlignedSamplesDF`](../Variables/AlignedSamplesDF.md) and [`AlignedSamples_RT_DF`](../Variables/AlignedSamples_RT_DF.md), enabling experiment-wide comparisons.
+
+## Code
+```python
+import numpy as np
+import pandas as pd
+import os
+import datetime
+from JoiningFeatures import *
+from ms2_SpectralSimilarityClustering import *
+def Features_ms2_SamplesAligment(ResultsFolderName,mz_min=254,mz_max=255,RT_min=0,RT_max=2000,RT_tol=30,mz_Tol=0,min_Int_Frac=1,cos_tol=0.9,ToReplace='.mzML.xlsx',ms2Folder='ms2_spectra',ToAdd='mzML',saveAlignedTable=False,name="SamplesAligment"):
+    home=os.getcwd()
+    ResultsFolder=home+'/'+ResultsFolderName
+    All_FeaturesTable,SamplesNames=JoiningFeatures(ResultsFolder=ResultsFolder,mz_min=mz_min,mz_max=mz_max,RT_min=RT_min,RT_max=RT_max,ToReplace=ToReplace)
+    Modules=ms2_SpectralSimilarityClustering(SummMS2_raw=All_FeaturesTable,SamplesNames=SamplesNames,mz_col=3,RT_col=2,RT_tol=RT_tol,mz_Tol=mz_Tol,sample_id_col=16,ms2_spec_id_col=15,ms2Folder=ms2Folder,ToAdd=ToAdd,min_Int_Frac=min_Int_Frac,cos_tol=cos_tol)
+    N_samples=len(SamplesNames)
+    N_Features=len(Modules)
+    AlignedSamplesMat=np.zeros((N_Features,N_samples+7))
+    AlignedSamples_RT_Mat=np.zeros((N_Features,N_samples+7))
+    for feature_id in np.arange(N_Features,dtype='int'):
+        Feature_module=Modules[feature_id]
+        FeatureTable=All_FeaturesTable[Feature_module,:]
+        AlignedSamplesMat[feature_id,0]=np.mean(FeatureTable[:,3])
+        AlignedSamplesMat[feature_id,1]=np.mean(FeatureTable[:,4])
+        AlignedSamplesMat[feature_id,2]=np.mean(FeatureTable[:,8])
+        AlignedSamplesMat[feature_id,3]=np.mean(FeatureTable[:,9])
+        AlignedSamplesMat[feature_id,4]=np.mean(FeatureTable[:,2])
+        AlignedSamplesMat[feature_id,5]=np.min(FeatureTable[:,12])
+        AlignedSamplesMat[feature_id,6]=np.max(FeatureTable[:,13])
+        Samples_ids=np.array(FeatureTable[:,16],dtype='int')
+        AlignedSamplesMat_loc=Samples_ids+7
+        AlignedSamplesMat[feature_id,AlignedSamplesMat_loc]=FeatureTable[:,5]
+        AlignedSamples_RT_Mat[feature_id,AlignedSamplesMat_loc]=FeatureTable[:,2]
+    AlignedSamples_RT_Mat[:,:7]=AlignedSamplesMat[:,:7].copy()
+    AlignedSamplesMat=AlignedSamplesMat[AlignedSamplesMat[:,0].argsort()]
+    AlignedSamples_RT_Mat=AlignedSamples_RT_Mat[AlignedSamples_RT_Mat[:,0].argsort()]
+    Columns=['mz_(Da)','mz_std_(Da)','mz_ConfidenceInterval_(Da)','mz_ConfidenceInterval_(ppm)','RT_(s)','min_RT_(s)','max_RT_(s)']+SamplesNames
+    AlignedSamplesDF=pd.DataFrame(AlignedSamplesMat,columns=Columns)
+    AlignedSamples_RT_DF=pd.DataFrame(AlignedSamples_RT_Mat,columns=Columns)
+    if saveAlignedTable:
+        date=datetime.datetime.now()
+        string_date=str(date)
+        string_date=string_date[:16].replace(':',"_")
+        string_date=string_date.replace(' ',"_")
+        name=name+"_"+string_date+'.xlsx'
+        AlignedSamplesDF.to_excel(name)
+        AlignedSamples_RT_DF.to_excel('RT_'+name)
+    return [AlignedSamplesDF,AlignedSamples_RT_DF]
+```
+
+## Key operations
+- Uses [`JoiningFeatures`](./JoiningFeatures.md) to stack per-sample tables into [`All_FeaturesTable`](../Variables/All_FeaturesTable.md).
+- Clusters rows across samples using cosine similarity and RT/m/z tolerances.
+- Computes consensus statistics (average m/z, CI, RT, umbrella bounds) per module.
+- Populates two matrices: one with sample intensities (column 5 values) and one with sample RTs.
+- Optionally writes Excel files with timestamps for archival purposes.
+
+## Parameters
+- `ResultsFolderName (str)`: directory containing per-sample feature spreadsheets.
+- `mz_min/max`, `RT_min/max`: coarse filters applied before alignment.
+- `RT_tol`, `mz_Tol`: tolerances passed to the clustering routine.
+- `min_Int_Frac`, `cos_tol`: cosine similarity constraints.
+- `ToReplace`: suffix removed from filenames when deriving sample names.
+- `ms2Folder`, `ToAdd`: used when reloading raw spectra inside `ms2_SpectralSimilarityClustering`.
+- `saveAlignedTable (bool)`, `name (str)`: control Excel export.
+
+## Input
+- [`All_FeaturesTable`](../Variables/All_FeaturesTable.md)
+
+## Output
+- [`AlignedSamplesDF`](../Variables/AlignedSamplesDF.md)
+- [`AlignedSamples_RT_DF`](../Variables/AlignedSamples_RT_DF.md)
+
+## Functions
+- [`JoiningFeatures`](./JoiningFeatures.md)
+- [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md)
+
+## Called by
+- Alignment notebooks and downstream statistical workflows.
+
+## Examples
+```python
+from Functions.Features_ms2_SamplesAligment import Features_ms2_SamplesAligment
+AlignedDF, AlignedRT = Features_ms2_SamplesAligment('results', mz_min=250, mz_max=800,
+                                                    RT_min=0, RT_max=1500, RT_tol=20,
+                                                    cos_tol=0.95)
+print(AlignedDF.head())
+```
+Visualize intensities for a feature across samples:
+```python
+import matplotlib.pyplot as plt
+row = AlignedDF.iloc[0]
+row.iloc[7:].plot(kind='bar')
+plt.ylabel('Intensity (a.u.)')
+plt.title(f"Feature at m/z {row['mz_(Da)']:.4f}")
+plt.show()
+```

--- a/documentation/Functions/Find_ms2Peak.md
+++ b/documentation/Functions/Find_ms2Peak.md
@@ -1,0 +1,45 @@
+---
+title: Find_ms2Peak
+kind: function
+source: Functions/Find_ms2Peak.py
+last_updated: 2025-02-14
+---
+
+## Description
+Slices a raw MS2 spectrum around a target m/z, expanding the window if too few points are found. Provides the raw data used by [`ms2Peak`](./ms2Peak.md).
+
+## Code
+```python
+import numpy as np
+def Find_ms2Peak(RawSpectrum,mz,mz_std=2e-3,stdDistance=3,minSignals=4,count=0,MaxCount=3,minInt=1e3,RelativeContribution=False):
+    if count==MaxCount:
+        return []
+    min_mz_peak=mz-mz_std*stdDistance
+    max_mz_peak=mz+mz_std*stdDistance
+    peakFilter=(RawSpectrum[:,0]>min_mz_peak)&(RawSpectrum[:,0]<max_mz_peak)&(RawSpectrum[:,1]>0)
+    PeakData=RawSpectrum[peakFilter,:]
+    if RelativeContribution:
+        PeakInt=sum(PeakData[:,1])
+        TotalInt=sum(RawSpectrum[:,1])
+        relative_contribution=[int(PeakInt/TotalInt*100)]
+    if (len(PeakData[:,0])<minSignals) and (count<MaxCount):
+        PeakData=Find_ms2Peak(RawSpectrum=RawSpectrum,mz=mz,mz_std=mz_std,stdDistance=stdDistance+1,count=count+1,minInt=minInt,minSignals=minSignals)
+    return PeakData
+```
+
+## Parameters
+- `RawSpectrum`: MS2 array.
+- `mz`, `mz_std`, `stdDistance`: window definition.
+- `minSignals`, `MaxCount`: control recursion when few points are present.
+- `RelativeContribution (bool)`: optional flag to compute peak contribution.
+
+## Output
+- `PeakData`: filtered subset of the spectrum.
+
+## Called by
+- [`ms2Peak`](./ms2Peak.md)
+
+## Example
+```python
+window = Find_ms2Peak(RawSpectrum, mz=150.02)
+```

--- a/documentation/Functions/GaussianPeak.md
+++ b/documentation/Functions/GaussianPeak.md
@@ -1,0 +1,67 @@
+---
+title: GaussianPeak
+kind: function
+source: Functions/GaussianPeak.py
+last_updated: 2025-02-14
+---
+
+## Description
+`GaussianPeak` evaluates a normalized Gaussian curve across an m/z grid. It is the core model for both MS1 and MS2 peaks, providing the theoretical intensity profile used by [`Normal_Fit`](./Normal_Fit.md) and downstream chromatogram deconvolution modules. 
+
+**Math notes**  
+Given centroid \(\mu\), standard deviation \(\sigma\), and integrated intensity \(I_{\text{total}}\), the function returns
+\[
+I(m/z) = \frac{I_{\text{total}}}{\sigma \sqrt{2\pi}} \exp\left(-\frac{(m/z-\mu)^2}{2\sigma^2}\right)
+\]
+which preserves \(\int I(m/z)\,dm/z = I_{\text{total}}\).
+
+## Code
+```python
+import numpy as np
+def GaussianPeak(mz_vec,mz,mz_std,I_total):
+    LogVec=-((mz_vec-mz)/mz_std)**2/2
+    f1_sqrt2pi=0.3989422804014327 #1/np.sqrt(np.pi*2)
+    Gaussian_Int=np.exp(LogVec)*f1_sqrt2pi*I_total/mz_std
+    return Gaussian_Int
+```
+
+## Key operations
+- Computes the exponent term `LogVec` to avoid repeated power operations.
+- Uses the precomputed factor `1/sqrt(2π)` for speed and numerical stability.
+- Returns a numpy vector matching the length of `mz_vec`.
+
+## Parameters
+- `mz_vec (np.ndarray)`: Axis of m/z values where the Gaussian will be evaluated.
+- `mz (float)`: Gaussian centroid (Da); corresponds to the precursor or fragment mass.
+- `mz_std (float)`: Standard deviation (Da); derived from resolving power.
+- `I_total (float)`: Integrated intensity ensuring area conservation.
+
+## Input
+- Called by [`Normal_Fit`](./Normal_Fit.md) with peak windows from [`mzPeak`](./mzPeak.md) or chromatogram solvers.
+
+## Output
+- Returns `Gaussian_Int`, a numpy array of modeled intensities aligned with `mz_vec`.
+
+## Functions
+- Uses `numpy` only.
+
+## Called by
+- [`Normal_Fit`](./Normal_Fit.md) when fitting MS1 peaks.
+- Chromatogram simulation utilities (e.g., `GaussianChromatogram`, GA modules).
+
+## Examples
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from Functions.GaussianPeak import GaussianPeak
+
+mz_axis = np.linspace(300.11, 300.14, 400)
+model = GaussianPeak(mz_axis, mz=300.125, mz_std=2e-3, I_total=1e6)
+
+plt.plot(mz_axis, model)
+plt.xlabel('m/z (Da)')
+plt.ylabel('Intensity (a.u.)')
+plt.title('Gaussian peak at 300.125 Da')
+plt.show()
+```
+This snippet generates the theoretical profile used when estimating MS1 centroid and standard deviation.

--- a/documentation/Functions/JoiningFeatures.md
+++ b/documentation/Functions/JoiningFeatures.md
@@ -1,0 +1,79 @@
+---
+title: JoiningFeatures
+kind: function
+source: Functions/JoiningFeatures.py
+last_updated: 2025-02-14
+---
+
+## Description
+`JoiningFeatures` scans a results folder for per-sample feature spreadsheets (typically exported from [`Cluster_ms2_Features`](./Cluster_ms2_Features.md) or downstream notebooks), loads them into numpy arrays, appends the sample index, and concatenates them into [`All_FeaturesTable`](../Variables/All_FeaturesTable.md). This prepares the data for cross-sample alignment.
+
+## Code
+```python
+import pandas as pd
+import numpy as np
+import os
+def JoiningFeatures(ResultsFolder,mz_min=0,mz_max=1200,RT_min=0,RT_max=2000,ToReplace='.mzML.xlsx'):
+    SamplesNames=[]
+    SamplesList=os.listdir(ResultsFolder)
+    SamplesList.sort()
+    N_samples=len(SamplesList)
+    firstTable=True
+    for sample_id in np.arange(N_samples,dtype='int'):
+        features_table=SamplesList[sample_id]
+        sample_name=features_table.replace(ToReplace,'')
+        SamplesNames.append(sample_name)
+        features_table_name=ResultsFolder+'/'+features_table
+        FeaturesTableDF=pd.read_excel(features_table_name,index_col=0)
+        FeaturesTable=np.array(FeaturesTableDF)
+        N_features=len(FeaturesTable[:,0])
+        featureLocVec=np.ones(N_features).reshape(-1,1)*sample_id
+        FeaturesTable=np.append(FeaturesTable,featureLocVec,axis=1)
+        if firstTable:
+            All_FeaturesTable=FeaturesTable
+            firstTable=False
+        else:
+            All_FeaturesTable=np.append(All_FeaturesTable,FeaturesTable,axis=0)
+    Filter=(All_FeaturesTable[:,3]>mz_min)&(All_FeaturesTable[:,3]<mz_max)&(All_FeaturesTable[:,2]>RT_min)&(All_FeaturesTable[:,2]<RT_max)
+    All_FeaturesTable=All_FeaturesTable[Filter,:]
+    return [All_FeaturesTable,SamplesNames]
+```
+
+## Key operations
+- Reads every file in `ResultsFolder`, sorts them for deterministic sample ordering, and derives `SamplesNames` by stripping `ToReplace` from filenames.
+- Converts each Excel table to numpy, appends a column filled with the integer `sample_id`, and concatenates vertically.
+- Applies coarse `mz`/`RT` filters to trim the merged array.
+
+## Parameters
+- `ResultsFolder (str)`: directory containing per-sample Excel outputs.
+- `mz_min/max`, `RT_min/max`: filters applied after merging.
+- `ToReplace`: suffix removed from filenames to obtain sample names.
+
+## Input
+- Excel files exported from feature detection (one per sample).
+
+## Output
+- [`All_FeaturesTable`](../Variables/All_FeaturesTable.md)
+- `SamplesNames` (list of strings)
+
+## Functions
+- Uses pandas for I/O and numpy for concatenation.
+
+## Called by
+- [`Features_ms2_SamplesAligment`](./Features_ms2_SamplesAligment.md)
+
+## Examples
+```python
+from Functions.JoiningFeatures import JoiningFeatures
+All_FeaturesTable, SampleNames = JoiningFeatures('results', mz_min=250, mz_max=800)
+print('Merged features:', All_FeaturesTable.shape[0])
+print('Samples:', SampleNames)
+```
+Visualize the distribution of sample IDs in the merged table:
+```python
+import matplotlib.pyplot as plt
+plt.hist(All_FeaturesTable[:,16], bins=range(len(SampleNames)+1))
+plt.xlabel('Sample ID')
+plt.ylabel('Number of features')
+plt.show()
+```

--- a/documentation/Functions/Normal_Fit.md
+++ b/documentation/Functions/Normal_Fit.md
@@ -1,0 +1,76 @@
+---
+title: Normal_Fit
+kind: function
+source: Functions/Normal_Fit.py
+last_updated: 2025-02-14
+---
+
+## Description
+`Normal_Fit` performs a nonlinear least-squares fit of the Gaussian model (`GaussianPeak`) to MS1 peak windows extracted by `mzPeak`. It returns the optimized centroid, width, intensity, and r² goodness-of-fit, enabling [`ms2_features_stats`](./ms2_features_stats.md) to quantify precursor precision.
+
+## Code
+```python
+from scipy.optimize import curve_fit
+from GaussianPeak import *
+from r2_Gauss import *
+def Normal_Fit(PeakData_and_Stats):
+    PeakData=PeakData_and_Stats[0]
+    GaussStats=PeakData_and_Stats[1]
+    mz=GaussStats[0]
+    mz_std=GaussStats[1]
+    I_total=GaussStats[4]
+    GaussianParameters=list(curve_fit(GaussianPeak, xdata=PeakData[:,0], ydata=PeakData[:,1],p0=[mz,mz_std,I_total])[0])
+    r2=r2_Gauss(PeakData,GaussianParameters)
+    NormalParameters=GaussianParameters+r2
+    return NormalParameters
+```
+
+## Key operations
+- Extracts initial guesses (`mz`, `mz_std`, `I_total`) from `GaussStats` (pre-fit stats from `mzPeak`).
+- Calls `scipy.optimize.curve_fit` with `GaussianPeak` as the model.
+- Computes coefficient of determination via [`r2_Gauss`](./r2_Gauss.md).
+- Returns `[mz_fit, mz_std_fit, I_total_fit, r²]`.
+
+## Parameters
+- `PeakData_and_Stats`: tuple/list containing `PeakData` (Nx2 array of `[m/z, intensity]`) and `GaussStats` (initial parameters).
+
+## Input
+- Provided by `mzPeak` inside [`ms2_features_stats`](./ms2_features_stats.md).
+
+## Output
+- `NormalParameters`: list `[mz, mz_std, I_total, r²]`.
+
+## Functions
+- [`GaussianPeak`](./GaussianPeak.md)
+- [`r2_Gauss`](./r2_Gauss.md)
+- `scipy.optimize.curve_fit`
+
+## Called by
+- [`ms2_features_stats`](./ms2_features_stats.md)
+- Chromatogram GA modules when refining peaks.
+
+## Examples
+```python
+import numpy as np
+from Functions.Normal_Fit import Normal_Fit
+
+PeakData = np.array([
+    [300.120, 1.0e5],
+    [300.123, 1.5e5],
+    [300.126, 1.0e5]
+])
+GaussStats = [300.123, 0.002, None, None, PeakData[:,1].sum()]
+PeakData_and_Stats = [PeakData, GaussStats, 10021]
+params = Normal_Fit(PeakData_and_Stats)
+print('mz_fit:', params[0], 'r2:', params[3])
+```
+Plotting the fitted curve:
+```python
+import matplotlib.pyplot as plt
+from Functions.GaussianPeak import GaussianPeak
+mz_axis = np.linspace(300.118, 300.128, 200)
+fit_curve = GaussianPeak(mz_axis, params[0], params[1], params[2])
+plt.plot(PeakData[:,0], PeakData[:,1], 'o', label='MS1 data')
+plt.plot(mz_axis, fit_curve, '-', label='Gaussian fit')
+plt.legend(); plt.show()
+```

--- a/documentation/Functions/Retrieve_and_Join_ms2_for_feature.md
+++ b/documentation/Functions/Retrieve_and_Join_ms2_for_feature.md
@@ -1,0 +1,81 @@
+---
+title: Retrieve_and_Join_ms2_for_feature
+kind: function
+source: Functions/Retrieve_and_Join_ms2_for_feature.py
+last_updated: 2025-02-14
+---
+
+## Description
+`Retrieve_and_Join_ms2_for_feature` loads raw MS2 spectra (CSV files) associated with a set of feature rows. Each spectrum is appended with the feature index and filtered by minimum relative intensity. The concatenated array feeds fragment-level clustering inside [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md).
+
+## Code
+```python
+import pandas as pd
+import numpy as np
+import os
+def Retrieve_and_Join_ms2_for_feature(All_FeaturesTable,Feature_module,SamplesNames,sample_id_col=16,ms2_spec_id_col=15,ms2Folder='ms2_spectra',ToAdd='mzML',min_Int_Frac=2):
+    N_features=len(Feature_module)
+    FeatureTable=All_FeaturesTable[Feature_module,:].copy()
+    firstSpec=True
+    All_ms2=[]
+    for feature_id in np.arange(N_features,dtype='int'):
+        features_stats=FeatureTable[feature_id,:]
+        if sample_id_col>0:
+            sample_id=int(features_stats[sample_id_col])
+        else:
+            sample_id=0
+        ms2_spec_id=str(int(features_stats[ms2_spec_id_col]))
+        sample_name_id=SamplesNames[sample_id]+ToAdd
+        ms2_spectrumLoc=ms2Folder+'/'+sample_name_id+'/'+ms2_spec_id+'.csv'
+        ExistSpectrum=os.path.exists(ms2_spectrumLoc)
+        if ExistSpectrum:
+            ms2_spectrumDF=pd.read_csv(ms2_spectrumLoc,index_col=0)
+            ms2_spectrum=np.array(ms2_spectrumDF)
+            N_peaks=len(ms2_spectrum[:,0])
+            SpectrumLocVec=np.ones(N_peaks).reshape(-1,1)*feature_id
+            ms2_spectrum=np.append(ms2_spectrum,SpectrumLocVec,axis=1)
+            if firstSpec:
+                All_ms2=ms2_spectrum
+                firstSpec=False
+            else:
+                All_ms2=np.append(All_ms2,ms2_spectrum,axis=0)
+    if len(All_ms2)==0:
+        return []
+    IntFrac_ms2_filter=All_ms2[:,9]>min_Int_Frac
+    All_ms2=All_ms2[IntFrac_ms2_filter,:]
+    return All_ms2
+```
+
+## Key operations
+- Constructs file paths `ms2Folder/sampleName+ToAdd/ms2_spec_id.csv` for each feature.
+- Loads spectra into numpy arrays and appends a column with the local `feature_id`.
+- Filters fragments by relative intensity (`column 9 > min_Int_Frac`).
+
+## Parameters
+- `All_FeaturesTable`: stacked features.
+- `Feature_module`: indices pointing to rows belonging to one cluster.
+- `SamplesNames`: list mapping sample IDs to folder prefixes.
+- `sample_id_col`, `ms2_spec_id_col`: column indices for sample and MS2 IDs.
+- `ms2Folder`, `ToAdd`: folder structure hints.
+- `min_Int_Frac`: minimum relative intensity percentage.
+
+## Input
+- [`All_FeaturesTable`](../Variables/All_FeaturesTable.md)
+- Disk-stored MS2 spectra.
+
+## Output
+- `All_ms2`: numpy array containing concatenated MS2 fragments with appended feature indices.
+
+## Functions
+- Uses pandas and numpy only.
+
+## Called by
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Examples
+```python
+from Functions.Retrieve_and_Join_ms2_for_feature import Retrieve_and_Join_ms2_for_feature
+All_ms2 = Retrieve_and_Join_ms2_for_feature(All_FeaturesTable, Feature_module=[0,1],
+                                           SamplesNames=['Sample_A','Sample_B'])
+print(All_ms2.shape)
+```

--- a/documentation/Functions/Update_ids_FeatureModules.md
+++ b/documentation/Functions/Update_ids_FeatureModules.md
@@ -1,0 +1,38 @@
+---
+title: Update_ids_FeatureModules
+kind: function
+source: Functions/Update_ids_FeatureModules.py
+last_updated: 2025-02-14
+---
+
+## Description
+Maps module indices computed on temporary arrays back to the original feature indices. Essential when clustering operates on zero-based slices but alignment expects absolute row numbers.
+
+## Code
+```python
+import numpy as np
+def Update_ids_FeatureModules(Feature_module,Feature_Modules):
+    npFeature_module=np.array(Feature_module)
+    Modules=[]
+    for module in Feature_Modules:
+        feature_module=list(npFeature_module[module])
+        Modules.append(feature_module)
+    return Modules
+```
+
+## Parameters
+- `Feature_module`: original list/array of feature IDs passed to the clustering stage.
+- `Feature_Modules`: list of lists with indices relative to `Feature_module`.
+
+## Output
+- New list of modules expressed in original indices.
+
+## Called by
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Example
+```python
+Feature_module = [10, 25, 30]
+Feature_Modules = [[0,1],[2]]
+print(Update_ids_FeatureModules(Feature_module, Feature_Modules))  # [[10,25],[30]]
+```

--- a/documentation/Functions/WriteLog.md
+++ b/documentation/Functions/WriteLog.md
@@ -1,0 +1,47 @@
+---
+title: WriteLog
+kind: function
+source: Functions/WriteLog.py
+last_updated: 2025-02-14
+---
+
+## Description
+`WriteLog` records failed MS2 peak fits. It estimates the relative contribution of the targeted peak to the total spectrum, formats diagnostic parameters, and appends the entry to `LogFileName`. This information helps troubleshoot `ms2_peak_stats` failures.
+
+## Code
+```python
+from ms2Peak_contribution import *
+from Parameters_to_string import *
+def WriteLog(RawSpectrum,Parameters,TotalInt,LogFileName='LogMS2_peaks.csv'):
+    mz=Parameters[2]
+    mz_std=Parameters[3]
+    stdDistance=Parameters[4]
+    relative_contribution=ms2Peak_contribution(RawSpectrum=RawSpectrum,TotalInt=TotalInt,mz=mz,mz_std=mz_std,stdDistance=stdDistance)
+    Parameters=relative_contribution+Parameters
+    toWrite=Parameters_to_string(Parameters)
+    LogFile=open(LogFileName,'a')
+    LogFile.write(toWrite)
+    LogFile.close()
+```
+
+## Key operations
+- Calls `ms2Peak_contribution` to quantify how much of the spectrum falls within the Gaussian window.
+- Uses `Parameters_to_string` to serialize the metadata into CSV-friendly text.
+- Appends to the log file without overwriting previous entries.
+
+## Parameters
+- `RawSpectrum`: raw MS2 data.
+- `Parameters`: list passed from [`ms2_peakStats_safe`](./ms2_peakStats_safe.md), typically `[DataSetName, ms_id, mz, ...]`.
+- `TotalInt`: sum of intensities for normalization.
+- `LogFileName`: path of the log file.
+
+## Output
+- None (side effect: file append).
+
+## Called by
+- [`ms2_peakStats_safe`](./ms2_peakStats_safe.md)
+
+## Example
+```python
+WriteLog(RawSpectrum, Parameters=['Sample', 10, 150.02, 2e-3, 3], TotalInt=RawSpectrum[:,1].sum())
+```

--- a/documentation/Functions/closest_ms1_spec.md
+++ b/documentation/Functions/closest_ms1_spec.md
@@ -1,0 +1,61 @@
+---
+title: closest_ms1_spec
+kind: function
+source: Functions/closest_ms1_spec.py
+last_updated: 2025-02-14
+---
+
+## Description
+`closest_ms1_spec` selects MS1 scan indices that immediately precede a given MS2 event. It filters [`MS1IDVec`](../Variables/MS1IDVec.md) to scans acquired before `MS2_Fullsignal_id`, computes RT differences relative to the MS2 RT, and returns the scan IDs sorted by proximity. This ensures Gaussian fits in [`ms2_features_stats`](./ms2_features_stats.md) use the most relevant chromatographic slices.
+
+## Code
+```python
+import numpy as np
+def closest_ms1_spec(mz,RT,MS2_Fullsignal_id,SummMS2,MS1IDVec,MS2_to_MS1_ratio=10):
+    ID_filter=(MS1IDVec[:,0]<MS2_Fullsignal_id)&(MS1IDVec[:,0]>(MS2_Fullsignal_id-MS2_to_MS1_ratio)) #The MS2 is generated with the ions from the MS1, so the MS2 RT and id, would be higher
+    Earlier_MS1IDVec=MS1IDVec[ID_filter,:]
+    RT_DifVec=RT-Earlier_MS1IDVec[:,1]
+    Min_RT_Dif=np.min(RT_DifVec)
+    Closest_MS1_Loc=np.where(RT_DifVec==Min_RT_Dif)[0]
+    spectrum_idVec=Earlier_MS1IDVec[RT_DifVec.argsort(),0]
+    return spectrum_idVec
+```
+
+## Key operations
+- Limits the search to `MS2_to_MS1_ratio` scans before the MS2 event, assuming DDA scheduling.
+- Computes `RT_DifVec` and sorts ascending to prioritize MS1 scans closest in time.
+- Returns only the scan IDs (first column) for downstream extraction.
+
+## Parameters
+- `mz (float)`: not used internally but retained for compatibility.
+- `RT (float)`: MS2 retention time.
+- `MS2_Fullsignal_id (int)`: MS2 scan index.
+- `SummMS2`: not used; kept for symmetry with other functions.
+- `MS1IDVec`: array of `[MS1_scan_id, RT]` pairs.
+- `MS2_to_MS1_ratio (int)`: window size in scan counts.
+
+## Input
+- Provided with `MS1IDVec` from `MS_L_IDs` and metadata from [`SummMS2`](../Variables/SummMS2.md).
+
+## Output
+- `spectrum_idVec`: numpy array of MS1 scan IDs sorted by RT proximity.
+
+## Functions
+- Uses numpy only.
+
+## Called by
+- [`ms2_features_stats`](./ms2_features_stats.md)
+- Chromatogram reconstruction helpers (e.g., `RetrieveChromatogram`).
+
+## Examples
+```python
+import numpy as np
+from Functions.closest_ms1_spec import closest_ms1_spec
+
+MS1IDVec = np.array([[18000, 245.1], [18001, 245.3], [18002, 245.5], [18003, 245.8]])
+SummMS2 = np.array([[300.12, 245.6, 18240]])
+spectrum_ids = closest_ms1_spec(mz=300.12, RT=245.6, MS2_Fullsignal_id=18240,
+                                 SummMS2=SummMS2, MS1IDVec=MS1IDVec, MS2_to_MS1_ratio=5)
+print(spectrum_ids)
+```
+This returns MS1 scan IDs ordered by proximity to the MS2 RT for subsequent Gaussian fitting.

--- a/documentation/Functions/feat_ms2_Gauss.md
+++ b/documentation/Functions/feat_ms2_Gauss.md
@@ -1,0 +1,89 @@
+---
+title: feat_ms2_Gauss
+kind: function
+source: Functions/feat_ms2_Gauss.py
+last_updated: 2025-02-14
+---
+
+## Description
+`feat_ms2_Gauss` iterates over every MS2 detection in [`SummMS2`](../Variables/SummMS2.md), calls [`ms2_features_stats`](./ms2_features_stats.md) to obtain MS1-refined Gaussian parameters, and aggregates the results into the [`MS2_Features`](../Variables/MS2_Features.md) array. Chromatographic umbrella metadata (`min_RT`, `max_RT`, `N_spec`, `ms2_spec_id`) are appended from `SummMS2` to preserve MS2 provenance.
+
+## Code
+```python
+import numpy as np
+from ms2_features_stats import *
+from Cluster_ms2_Features import *
+def feat_ms2_Gauss(DataSet,SummMS2,MS1IDVec,mz_std=2e-3,MS2_to_MS1_ratio=10,stdDistance=3,MaxCount=3,Points_for_regression=5,minSignals=7):
+    MS2_features=[]
+    N_MS2_features=len(SummMS2[:,0])
+    for MS2_id in np.arange(N_MS2_features,dtype='int'):
+        while True:
+            try:
+                min_RT=SummMS2[MS2_id,5]
+                max_RT=SummMS2[MS2_id,6]
+                N_spec=SummMS2[MS2_id,7]
+                ms2_spec_id=int(SummMS2[MS2_id,8])
+                features_stats=ms2_features_stats(DataSet=DataSet,MS2_id=MS2_id,SummMS2=SummMS2,MS1IDVec=MS1IDVec,mz_std=mz_std,MS2_to_MS1_ratio=MS2_to_MS1_ratio,stdDistance=stdDistance,MaxCount=MaxCount,Points_for_regression=Points_for_regression,minSignals=minSignals)
+                if len(features_stats)>0:
+                    MS2_features.append(features_stats+[min_RT]+[max_RT]+[N_spec]+[ms2_spec_id])
+                break
+            except:
+                print('error',MS2_id)
+                break
+    MS2_features=np.array(MS2_features)
+    MS2_features=MS2_features[MS2_features[:,3].argsort(),:]
+   # ms2_FeaturesDF=Cluster_ms2_Features(MS2_features)
+    return MS2_features#ms2_FeaturesDF
+```
+
+## Key operations
+- Loops through every MS2 entry, ensuring umbrella metadata are captured alongside Gaussian fits.
+- Wraps the call to [`ms2_features_stats`](./ms2_features_stats.md) in a `try/except` to prevent the batch run from crashing.
+- Sorts the resulting array by fitted m/z (`MS2_features[:,3]`).
+- Optionally supports feature clustering (currently commented out) through [`Cluster_ms2_Features`](./Cluster_ms2_Features.md).
+
+## Parameters
+- `DataSet`: iterable of MS1 spectra (see [`DataSet`](../Variables/DataSet.md)).
+- `SummMS2`: MS2 summary table.
+- `MS1IDVec`: MS1 scan mapping.
+- `mz_std`, `stdDistance`, `MaxCount`, `Points_for_regression`, `minSignals`: forwarded to [`ms2_features_stats`](./ms2_features_stats.md).
+- `MS2_to_MS1_ratio`: ratio of MS1 scans to inspect per MS2 event.
+
+## Input
+- [`DataSet`](../Variables/DataSet.md)
+- [`SummMS2`](../Variables/SummMS2.md)
+- [`MS1IDVec`](../Variables/MS1IDVec.md)
+
+## Output
+- [`MS2_Features`](../Variables/MS2_Features.md)
+
+## Functions
+- [`ms2_features_stats`](./ms2_features_stats.md)
+- [`Cluster_ms2_Features`](./Cluster_ms2_Features.md) (optional)
+
+## Called by
+- Workflow notebooks constructing MS2-first feature tables.
+
+## Examples
+```python
+import numpy as np
+from Functions.feat_ms2_Gauss import feat_ms2_Gauss
+
+DataSet = [...]
+SummMS2 = np.array([
+    [300.123, 245.6, 18240, 1.2e6, 0.34, 240.1, 248.3, 3, 7021],
+    [450.201, 512.3, 19305, 8.5e5, 0.42, 509.7, 516.8, 2, 7150]
+])
+MS1IDVec = np.array([[18000, 245.2], [18005, 245.5], [18010, 245.8]])
+MS2_features = feat_ms2_Gauss(DataSet, SummMS2, MS1IDVec)
+```
+Visualize fitted m/z vs. umbrella RT:
+```python
+import matplotlib.pyplot as plt
+plt.scatter(MS2_features[:,3], MS2_features[:,4], c=MS2_features[:,6])
+plt.xlabel('mz (Da)')
+plt.ylabel('mz_std (Da)')
+plt.title('Gaussian widths by feature (color = r²)')
+plt.colorbar(label='Gauss r²')
+plt.show()
+```

--- a/documentation/Functions/ms2Peak.md
+++ b/documentation/Functions/ms2Peak.md
@@ -1,0 +1,48 @@
+---
+title: ms2Peak
+kind: function
+source: Functions/ms2Peak.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2Peak` extracts a local fragment window from `RawSpectrum`, optionally widening the window until enough points are available, and returns both the raw data and preliminary Gaussian statistics computed by [`mz_Gauss_std`](./mz_Gauss_std.md). It is used by [`ms2_peak_stats`](./ms2_peak_stats.md) to seed Gaussian fitting.
+
+## Code
+```python
+from Find_ms2Peak import *
+from mz_Gauss_std import *
+def ms2Peak(RawSpectrum,mz,mz_std=2e-3,stdDistance=3,minSignals=4,count=0,MaxCount=3,minInt=1e3,Points_for_regression=4):
+    PeakData=Find_ms2Peak(RawSpectrum=RawSpectrum,mz=mz,mz_std=mz_std,stdDistance=stdDistance,minSignals=minSignals,MaxCount=MaxCount,minInt=minInt)
+    if len(PeakData)==0:
+        return []
+    GaussStats=mz_Gauss_std(PeakData,Points_for_regression=Points_for_regression)
+    New_mz_std=GaussStats[1]
+    if New_mz_std>mz_std and count<MaxCount:
+        PeakData=ms2Peak(RawSpectrum=RawSpectrum,mz=mz,mz_std=New_mz_std,stdDistance=stdDistance,minSignals=minSignals,count=count+1,MaxCount=MaxCount,minInt=minInt,Points_for_regression=Points_for_regression)[0]
+    PeakData_and_Stats=[PeakData,GaussStats]
+    return PeakData_and_Stats
+```
+
+## Key operations
+- Calls [`Find_ms2Peak`](./Find_ms2Peak.md) to select data within ±`stdDistance * mz_std`.
+- Fits an initial Gaussian via [`mz_Gauss_std`](./mz_Gauss_std.md) and recursively widens the window if the estimated width grows.
+
+## Parameters
+- `RawSpectrum`: MS2 array.
+- `mz`, `mz_std`, `stdDistance`: initial window definition.
+- `minSignals`: minimum number of data points required.
+- `MaxCount`: recursion limit for widening.
+- `Points_for_regression`: number of points used when estimating Gaussian variance.
+- `minInt`: minimum intensity filter.
+
+## Output
+- `[PeakData, GaussStats]` where `PeakData` contains `[m/z, intensity]` samples and `GaussStats` includes centroid, std, intercept, r², and approximate area.
+
+## Called by
+- [`ms2_peak_stats`](./ms2_peak_stats.md)
+
+## Example
+```python
+peak_data, gauss_stats = ms2Peak(RawSpectrum, mz=150.02)
+```

--- a/documentation/Functions/ms2_FeaturesDifferences.md
+++ b/documentation/Functions/ms2_FeaturesDifferences.md
@@ -1,0 +1,86 @@
+---
+title: ms2_FeaturesDifferences
+kind: function
+source: Functions/ms2_FeaturesDifferences.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_FeaturesDifferences` refines feature clusters by comparing full MS2 spectra. Starting from an initial set of candidate indices (e.g., from [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md)), it reloads the raw MS2 spectra, aligns fragments, computes cosine similarities, and splits clusters when spectra diverge beyond `cos_tol`. The output modules feed alignment routines.
+
+## Code
+```python
+from Retrieve_and_Join_ms2_for_feature import *
+from AdjacencyList_ms2Fragments import *
+from ms2_feat_modules import *
+from AligniningFragments_in_Feature import *
+from CosineMatrix import *
+from AdjacencyList_from_matrix import *
+from ms2_feat_modules import *
+from Update_ids_FeatureModules import *
+def ms2_FeaturesDifferences(All_FeaturesTable,Feature_module,SamplesNames,sample_id_col=16,ms2_spec_id_col=15,ms2Folder='ms2_spectra',ToAdd='mzML',min_Int_Frac=2,cos_tol=0.9):
+    All_ms2=Retrieve_and_Join_ms2_for_feature(All_FeaturesTable=All_FeaturesTable,Feature_module=Feature_module,SamplesNames=SamplesNames,sample_id_col=sample_id_col,ms2_spec_id_col=ms2_spec_id_col,ms2Folder=ms2Folder,ToAdd=ToAdd,min_Int_Frac=min_Int_Frac)
+    if len(All_ms2)==0:
+        return []
+    AdjacencyListFragments,feat_ids=AdjacencyList_ms2Fragments(All_ms2=All_ms2)
+    N_features=len(Feature_module)
+    Frag_Modules=ms2_feat_modules(AdjacencyList=AdjacencyListFragments,ms2_ids=feat_ids)
+    AlignedFragmentsMat=AligniningFragments_in_Feature(Frag_Modules=Frag_Modules,All_ms2=All_ms2,N_features=N_features)
+    CosineMat=CosineMatrix(AlignedFragmentsMat=AlignedFragmentsMat,N_features=N_features)
+    AdjacencyList_Features,features_ids=AdjacencyList_from_matrix(AdjacencyMatrix=CosineMat,N_ms2_spectra=N_features,minAdjacency=cos_tol)
+    Feature_Modules=ms2_feat_modules(AdjacencyList=AdjacencyList_Features,ms2_ids=features_ids)
+    Feature_Modules=Update_ids_FeatureModules(Feature_module=Feature_module,Feature_Modules=Feature_Modules)
+    return Feature_Modules
+```
+
+## Key operations
+- Uses [`Retrieve_and_Join_ms2_for_feature`](./Retrieve_and_Join_ms2_for_feature.md) to load every MS2 spectrum for the candidate module.
+- Builds fragment-level adjacency lists and modules, then aligns fragments with [`AligniningFragments_in_Feature`](./AligniningFragments_in_Feature.md).
+- Computes cosine similarity matrix via [`CosineMatrix`](./CosineMatrix.md) and thresholds it using [`AdjacencyList_from_matrix`](./AdjacencyList_from_matrix.md).
+- Runs [`ms2_feat_modules`](./ms2_feat_modules.md) again on the similarity graph and re-maps indices to the original feature IDs with [`Update_ids_FeatureModules`](./Update_ids_FeatureModules.md).
+
+## Parameters
+- `All_FeaturesTable`: stacked feature rows from [`JoiningFeatures`](./JoiningFeatures.md).
+- `Feature_module (array-like)`: indices representing one coarse cluster.
+- `SamplesNames (list)`: used to build file paths when reading spectra.
+- `sample_id_col`, `ms2_spec_id_col`: columns in `All_FeaturesTable` storing sample IDs and raw MS2 IDs.
+- `ms2Folder`, `ToAdd`: file-system hints for locating mzML spectra.
+- `min_Int_Frac`: minimum fragment intensity fraction kept during alignment.
+- `cos_tol`: cosine similarity threshold for splitting clusters.
+
+## Input
+- [`All_FeaturesTable`](../Variables/All_FeaturesTable.md)
+- Candidate module indices from `ms2_SpectralSimilarityClustering`.
+
+## Output
+- `Feature_Modules`: list of refined modules (arrays of row indices) ready for alignment.
+
+## Functions
+- [`Retrieve_and_Join_ms2_for_feature`](./Retrieve_and_Join_ms2_for_feature.md)
+- [`AdjacencyList_ms2Fragments`](./AdjacencyList_ms2Fragments.md)
+- [`ms2_feat_modules`](./ms2_feat_modules.md)
+- [`AligniningFragments_in_Feature`](./AligniningFragments_in_Feature.md)
+- [`CosineMatrix`](./CosineMatrix.md)
+- [`AdjacencyList_from_matrix`](./AdjacencyList_from_matrix.md)
+- [`Update_ids_FeatureModules`](./Update_ids_FeatureModules.md)
+
+## Called by
+- [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md)
+
+## Examples
+```python
+from Functions.ms2_FeaturesDifferences import ms2_FeaturesDifferences
+modules = ms2_FeaturesDifferences(All_FeaturesTable, Feature_module=[0,1,2],
+                                  SamplesNames=['Sample_A','Sample_B'],
+                                  cos_tol=0.95)
+```
+Visualize cosine similarity matrix (mock data):
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+cosine_mat = np.random.rand(3,3)
+plt.imshow(cosine_mat, vmin=0, vmax=1, cmap='viridis')
+plt.colorbar(label='cosine similarity')
+plt.title('Fragment similarity heatmap')
+plt.show()
+```

--- a/documentation/Functions/ms2_SpectralRedundancy.md
+++ b/documentation/Functions/ms2_SpectralRedundancy.md
@@ -1,0 +1,96 @@
+---
+title: ms2_SpectralRedundancy
+kind: function
+source: Functions/ms2_SpectralRedundancy.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_SpectralRedundancy` reads an MS2 summary spreadsheet, filters rows by RT/m/z, clusters redundant spectra via [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md), and builds a condensed [`SummMS2`](../Variables/SummMS2.md) array per sample. Scientifically, it merges multiple MS2 acquisitions targeting the same precursor so that downstream modeling works with a single umbrella per compound.
+
+**Math notes**  
+Redundancy is resolved with cosine similarity (threshold `cos_tol`) plus RT/m/z adjacency tolerances. For each cluster, the function selects the spectrum with the highest fragment intensity (`mostInt_ms2Frag`) as representative and records umbrella statistics (`min_RT`, `max_RT`, `N_spec`).
+
+## Code
+```python
+import numpy as np
+import pandas as pd
+import os
+from ms2_SpectralSimilarityClustering import *
+def ms2_SpectralRedundancy(SummaryFile,min_RT=0,max_RT=1500,min_mz=0,max_mz=1200,ms2FolderName='ms2_spectra',ToReplace='mzML-ms2Summary.xlsx',mz_col=1,RT_col=2,RT_tol=20,mz_Tol=1e-2,sample_id_col=-1,ms2_spec_id_col=0,ToAdd='mzML',min_Int_Frac=2,cos_tol=0.9):
+    home=os.getcwd()
+    ms2Folder=home+'/'+ms2FolderName
+    SummaryFileName=ms2Folder+'/'+SummaryFile
+    SummMS2_raw=np.array(pd.read_excel(SummaryFileName))
+    Filter=(SummMS2_raw[:,1]>min_mz)&(SummMS2_raw[:,1]<max_mz)&(SummMS2_raw[:,2]>min_RT)&(SummMS2_raw[:,2]<max_RT)
+    SummMS2_raw=SummMS2_raw[Filter,:]
+    SampleName=SummaryFile.replace(ToReplace,'')
+    Modules=ms2_SpectralSimilarityClustering(SummMS2_raw=SummMS2_raw,SampleName=SampleName,mz_col=mz_col,RT_col=RT_col,RT_tol=RT_tol,mz_Tol=mz_Tol,sample_id_col=sample_id_col,ms2_spec_id_col=ms2_spec_id_col,ms2Folder=ms2Folder,ToAdd=ToAdd,min_Int_Frac=min_Int_Frac,cos_tol=cos_tol)
+    N_modules=len(Modules)
+    SummMS2=[]
+    for mod_p in np.arange(N_modules,dtype='int'):
+        mod=Modules[mod_p]
+        mod_loc=0
+        SummMS2_mod=SummMS2_raw[mod,:].copy()
+        min_RT=np.min(SummMS2_mod[:,2])
+        max_RT=np.max(SummMS2_mod[:,2])
+        N_spec=len(mod)
+        if N_spec>1:
+            mostInt_ms2Frag=np.max(SummMS2_mod[:,4])
+            mostInt_ms2Frag_Filter=SummMS2_mod[:,4]==mostInt_ms2Frag
+            mod_loc=int(np.where(mostInt_ms2Frag_Filter)[0])
+        SummMS2_mod=list(SummMS2_mod[mod_loc,:])
+        ms2_spec_id=SummMS2_mod[0]
+        SummMS2_mod=SummMS2_mod[1:]+[min_RT]+[max_RT]+[N_spec]+[ms2_spec_id]
+        SummMS2.append(SummMS2_mod)
+    SummMS2=np.array(SummMS2)
+    return SummMS2
+```
+
+## Key operations
+- Loads Excel summaries from `ms2_spectra/SummaryFile` and filters rows by RT/m/z bounds.
+- Calls [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md) to obtain redundancy modules using cosine similarity on MS2 fragment intensities.
+- For each module, finds the spectrum with maximum fragment intensity (column 4) to represent the cluster.
+- Computes `min_RT`, `max_RT`, and `N_spec`, then appends them plus the representative `ms2_spec_id` to each row to match the [`SummMS2`](../Variables/SummMS2.md) schema.
+
+## Parameters
+- `SummaryFile (str)`: Excel filename inside `ms2FolderName`.
+- `min_RT`, `max_RT`, `min_mz`, `max_mz`: filtering bounds.
+- `ms2FolderName (str)`: folder storing per-sample summaries.
+- `ToReplace`, `ToAdd`: strings controlling sample-name derivation.
+- `mz_col`, `RT_col`: column indices for m/z and RT in the summary file.
+- `RT_tol`, `mz_Tol`: tolerances passed to the clustering routine.
+- `sample_id_col`, `ms2_spec_id_col`: column indices used to track sample IDs and raw MS2 IDs.
+- `min_Int_Frac`, `cos_tol`: intensity fraction threshold and cosine similarity cutoff.
+
+## Input
+- [`SummMS2_raw`](../Variables/SummMS2.md) style table read from disk.
+- Access to spectral folders for retrieving raw spectra inside [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md).
+
+## Output
+- [`SummMS2`](../Variables/SummMS2.md)
+
+## Functions
+- [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md)
+
+## Called by
+- Notebooks when raw vendor files are already summarized into Excel tables.
+
+## Examples
+```python
+import numpy as np
+from Functions.ms2_SpectralRedundancy import ms2_SpectralRedundancy
+
+# Mocking by writing a temporary Excel file is omitted here; instead, assume SummMS2_raw is loaded.
+# You can call the function directly once a summary workbook exists in ms2_spectra/.
+SummMS2 = ms2_SpectralRedundancy('SampleA-mzML-ms2Summary.xlsx', min_RT=100, max_RT=800,
+                                 min_mz=200, max_mz=800, cos_tol=0.95)
+```
+To visualize redundancy resolution, plot `N_spec` per feature:
+```python
+import matplotlib.pyplot as plt
+plt.hist(SummMS2[:,7], bins=range(1,6))
+plt.xlabel('Number of redundant MS2 spectra')
+plt.ylabel('Count')
+plt.show()
+```

--- a/documentation/Functions/ms2_SpectralSimilarityClustering.md
+++ b/documentation/Functions/ms2_SpectralSimilarityClustering.md
@@ -1,0 +1,85 @@
+---
+title: ms2_SpectralSimilarityClustering
+kind: function
+source: Functions/ms2_SpectralSimilarityClustering.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_SpectralSimilarityClustering` groups MS2 detections that are close in m/z and RT and have similar fragment patterns. It constructs adjacency lists using [`AdjacencyListFeatures`](./AdjacencyListFeatures.md), refines them with cosine similarity scores computed inside [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md), and returns a list of feature modules. These modules drive redundancy removal in [`ms2_SpectralRedundancy`](./ms2_SpectralRedundancy.md) and multi-sample alignment.
+
+## Code
+```python
+import pandas as pd
+import numpy as np
+from AdjacencyListFeatures import *
+from ms2_feat_modules import *
+from ms2_FeaturesDifferences import *
+def ms2_SpectralSimilarityClustering(SummMS2_raw,SampleName='',SamplesNames=[],mz_col=1,RT_col=2,RT_tol=20,mz_Tol=1e-2,sample_id_col=-1,ms2_spec_id_col=0,ms2Folder='ms2_spectra',ToAdd='mzML',min_Int_Frac=2,cos_tol=0.9):
+    if len(SamplesNames)==0:
+        SamplesNames=[SampleName]
+    AdjacencyList,feat_ids=AdjacencyListFeatures(MS2_features=SummMS2_raw,mz_col=mz_col,RT_col=RT_col,RT_tol=RT_tol,mz_Tol=mz_Tol)
+    RawModules=ms2_feat_modules(AdjacencyList=AdjacencyList,ms2_ids=feat_ids)
+    Modules=[]
+    for Feature_module in RawModules:
+        Feature_Modules=ms2_FeaturesDifferences(All_FeaturesTable=SummMS2_raw,Feature_module=Feature_module,SamplesNames=SamplesNames,sample_id_col=sample_id_col,ms2_spec_id_col=ms2_spec_id_col,ms2Folder=ms2Folder,ToAdd=ToAdd,min_Int_Frac=min_Int_Frac,cos_tol=cos_tol)
+        Modules+=Feature_Modules
+    return Modules
+```
+
+## Key operations
+- Builds an adjacency list in RT/m/z space to limit pairwise comparisons to plausible neighbors.
+- Converts adjacency information into connected components via [`ms2_feat_modules`](./ms2_feat_modules.md).
+- Calls [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md) to compute cosine similarities using raw spectral files stored in `ms2Folder` and enforce `cos_tol` and `min_Int_Frac` constraints.
+- Returns a list where each entry is an array of row indices referencing `SummMS2_raw` (or `All_FeaturesTable`).
+
+## Parameters
+- `SummMS2_raw (np.ndarray)`: MS2 detections prior to redundancy removal.
+- `SampleName` / `SamplesNames`: textual identifiers for logging and retrieving files.
+- `mz_col`, `RT_col`: columns used for tolerance checks.
+- `RT_tol`, `mz_Tol`: bounds for adjacency creation.
+- `sample_id_col`, `ms2_spec_id_col`: positions of sample and MS2 IDs, used to fetch raw spectra.
+- `ms2Folder (str)`: path containing mzML-derived spectra needed for cosine comparisons.
+- `ToAdd (str)`: suffix inserted when constructing filenames.
+- `min_Int_Frac`: minimum intensity fraction for fragments compared during cosine calculations.
+- `cos_tol`: similarity threshold.
+
+## Input
+- Called by [`ms2_SpectralRedundancy`](./ms2_SpectralRedundancy.md) with `SummMS2_raw` arrays.
+- Also invoked by [`Features_ms2_SamplesAligment`](./Features_ms2_SamplesAligment.md) when clustering cross-sample features.
+
+## Output
+- `Modules`: list of numpy arrays (indices) describing feature clusters.
+
+## Functions
+- [`AdjacencyListFeatures`](./AdjacencyListFeatures.md)
+- [`ms2_feat_modules`](./ms2_feat_modules.md)
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Called by
+- [`ms2_SpectralRedundancy`](./ms2_SpectralRedundancy.md)
+- [`Features_ms2_SamplesAligment`](./Features_ms2_SamplesAligment.md)
+
+## Examples
+```python
+import numpy as np
+from Functions.ms2_SpectralSimilarityClustering import ms2_SpectralSimilarityClustering
+
+SummMS2_raw = np.array([
+    [7001, 300.123, 245.5, 1.0e5, 0.35, 0],
+    [7002, 300.125, 246.0, 0.9e5, 0.30, 0],
+    [7010, 450.200, 512.0, 1.5e5, 0.45, 0]
+])
+modules = ms2_SpectralSimilarityClustering(SummMS2_raw, SampleName='Sample_A', mz_col=1, RT_col=2,
+                                           RT_tol=30, mz_Tol=5e-3, cos_tol=0.9)
+print(modules)
+```
+For visualization, count cluster sizes:
+```python
+import matplotlib.pyplot as plt
+sizes = [len(mod) for mod in modules]
+plt.bar(range(len(sizes)), sizes)
+plt.xlabel('Module index')
+plt.ylabel('Size (spectra)')
+plt.show()
+```

--- a/documentation/Functions/ms2_feat_modules.md
+++ b/documentation/Functions/ms2_feat_modules.md
@@ -1,0 +1,62 @@
+---
+title: ms2_feat_modules
+kind: function
+source: Functions/ms2_feat_modules.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_feat_modules` converts an adjacency list (e.g., from [`AdjacencyListFeatures`](./AdjacencyListFeatures.md)) into connected components. It repeatedly selects an unvisited feature ID, performs graph traversal via [`AdjacencyClustering`](./AdjacencyClustering.md), and records the resulting module. The modules are used in redundancy removal and alignment.
+
+## Code
+```python
+from AdjacencyClustering import *
+def ms2_feat_modules(AdjacencyList,ms2_ids):
+    Modules=[]
+    while len(ms2_ids)>0:
+        ms2_candidate_id=list(ms2_ids)[0]
+        module=AdjacencyClustering(ms2_id=ms2_candidate_id,AdjacencyList=AdjacencyList)
+        ms2_ids=ms2_ids-set(module)
+        Modules.append(module)
+    return Modules
+```
+
+## Key operations
+- Maintains a set `ms2_ids` of unassigned vertices.
+- Calls [`AdjacencyClustering`](./AdjacencyClustering.md) to retrieve all nodes connected to the candidate.
+- Removes clustered IDs from `ms2_ids` and appends the module list.
+
+## Parameters
+- `AdjacencyList (list)`: neighbors per feature.
+- `ms2_ids (set)`: indices that still require clustering.
+
+## Input
+- Output from [`AdjacencyListFeatures`](./AdjacencyListFeatures.md) or fragment adjacency lists.
+
+## Output
+- `Modules`: list of lists (feature indices belonging to the same connected component).
+
+## Functions
+- [`AdjacencyClustering`](./AdjacencyClustering.md)
+
+## Called by
+- [`Cluster_ms2_Features`](./Cluster_ms2_Features.md)
+- [`ms2_SpectralSimilarityClustering`](./ms2_SpectralSimilarityClustering.md)
+- [`ms2_FeaturesDifferences`](./ms2_FeaturesDifferences.md)
+
+## Examples
+```python
+from Functions.ms2_feat_modules import ms2_feat_modules
+AdjacencyList = [ [0,1], [0,1], [2] ]
+modules = ms2_feat_modules(AdjacencyList, ms2_ids=set([0,1,2]))
+print(modules)  # [[0,1], [2]]
+```
+Visualize module sizes:
+```python
+import matplotlib.pyplot as plt
+sizes = [len(m) for m in modules]
+plt.bar(range(len(sizes)), sizes)
+plt.xlabel('Module index')
+plt.ylabel('# features')
+plt.show()
+```

--- a/documentation/Functions/ms2_features_stats.md
+++ b/documentation/Functions/ms2_features_stats.md
@@ -1,0 +1,103 @@
+---
+title: ms2_features_stats
+kind: function
+source: Functions/ms2_features_stats.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_features_stats` links an MS2 detection from [`SummMS2`](../Variables/SummMS2.md) to the nearest MS1 spectra stored in [`MS1IDVec`](../Variables/MS1IDVec.md), extracts the MS1 peak via `mzPeak`, fits a Gaussian using [`Normal_Fit`](./Normal_Fit.md), and computes confidence intervals on the precursor m/z. The output row forms the backbone of [`MS2_Features`](../Variables/MS2_Features.md).
+
+**Math notes**  
+Given \(N\) MS1 data points and fitted standard deviation \(\sigma\), the function propagates uncertainty via Student’s t:
+\[
+\text{CI}_{\text{Da}} = t_{1-\alpha, N-1} \frac{\sigma}{\sqrt{N}}, \qquad
+\text{CI}_{\text{ppm}} = 10^6 \frac{\text{CI}_{\text{Da}}}{m/z}
+\]
+This captures instrument resolving power and sampling density.
+
+## Code
+```python
+from scipy import stats
+from mzPeak import *
+from closest_ms1_spec import *
+from Normal_Fit import *
+def ms2_features_stats(DataSet,MS2_id,SummMS2,MS1IDVec,mz_std=2e-3,MS2_to_MS1_ratio=10,stdDistance=3,MaxCount=3,Points_for_regression=5,minSignals=7,alpha=0.01):
+    RT=SummMS2[MS2_id,1]
+    mz=SummMS2[MS2_id,0]
+    MS2_Fullsignal_id=SummMS2[MS2_id,2]
+    spectrum_idVec=closest_ms1_spec(mz=mz,RT=RT,MS2_Fullsignal_id=MS2_Fullsignal_id,SummMS2=SummMS2,MS1IDVec=MS1IDVec,MS2_to_MS1_ratio=MS2_to_MS1_ratio)
+    PeakData_and_Stats=mzPeak(DataSet=DataSet,spectrum_idVec=spectrum_idVec,mz=mz,mz_std=mz_std,stdDistance=stdDistance,MaxCount=MaxCount,Points_for_regression=Points_for_regression,minSignals=minSignals)
+    if len(PeakData_and_Stats)==0:
+        return []
+    spectrum_id=[int(PeakData_and_Stats[2])]
+    NormalParameters=Normal_Fit(PeakData_and_Stats=PeakData_and_Stats)
+    Nsignals=len(PeakData_and_Stats[0][:,0])
+    mz=NormalParameters[0]
+    mz_std=NormalParameters[1]
+    min_mz=[mz-stdDistance*mz_std]
+    max_mz=[mz+stdDistance*mz_std]
+    tref=stats.t.interval(1-alpha, Nsignals-1)[1]
+    ConfidenceIntervalDa=[tref*mz_std/np.sqrt(Nsignals)]
+    ConfidenceInterval=[tref*mz_std/np.sqrt(Nsignals)/mz*1e6]
+    features_stats=[int(MS2_Fullsignal_id)]+spectrum_id+[RT]+NormalParameters+[Nsignals]+ConfidenceIntervalDa+ConfidenceInterval+min_mz+max_mz
+    return features_stats
+```
+
+## Key operations
+- Retrieves MS2 metadata (`mz`, `RT`, `MS2_Fullsignal_id`).
+- Uses [`closest_ms1_spec`](./closest_ms1_spec.md) to find MS1 scan IDs preceding the MS2 event.
+- Calls `mzPeak` to extract MS1 peak data centered on the MS2 m/z.
+- Fits a Gaussian via [`Normal_Fit`](./Normal_Fit.md) to obtain refined `mz`, `mz_std`, and `I_total` along with `r²`.
+- Calculates confidence intervals and integration bounds, packaging them into a single list.
+
+## Parameters
+- `DataSet`: see [`DataSet`](../Variables/DataSet.md).
+- `MS2_id (int)`: row index inside [`SummMS2`](../Variables/SummMS2.md).
+- `SummMS2`: MS2 summary table.
+- `MS1IDVec`: MS1 scan mapping.
+- `mz_std`, `stdDistance`: initial Gaussian window for MS1 extraction.
+- `MS2_to_MS1_ratio`: number of MS1 scans inspected relative to the MS2 scan index.
+- `MaxCount`, `Points_for_regression`, `minSignals`: controls for `mzPeak`.
+- `alpha`: significance level for the t-interval.
+
+## Input
+- [`DataSet`](../Variables/DataSet.md)
+- [`SummMS2`](../Variables/SummMS2.md)
+- [`MS1IDVec`](../Variables/MS1IDVec.md)
+
+## Output
+- List containing `[ms2_id, ms1_id, RT, mz, mz_std, I_total, r², N_points, CI_Da, CI_ppm, min_mz, max_mz]`.
+
+## Functions
+- [`closest_ms1_spec`](./closest_ms1_spec.md)
+- [`mzPeak`](./mzPeak.md)
+- [`Normal_Fit`](./Normal_Fit.md)
+- `scipy.stats.t.interval`
+
+## Called by
+- [`feat_ms2_Gauss`](./feat_ms2_Gauss.md)
+
+## Examples
+```python
+import numpy as np
+from Functions.ms2_features_stats import ms2_features_stats
+
+# Mock datasets: replace with actual loaders in production
+DataSet = [...]  # iterable of MS1 spectra
+SummMS2 = np.array([[300.123, 245.6, 18240, 1.2e6, 0.34, 240.1, 248.3, 3, 7021]])
+MS1IDVec = np.array([[18000, 245.2], [18005, 245.5], [18010, 245.8]])
+
+feature = ms2_features_stats(DataSet=DataSet, MS2_id=0, SummMS2=SummMS2,
+                             MS1IDVec=MS1IDVec, minSignals=5, alpha=0.01)
+```
+To visualize confidence intervals (mock data):
+```python
+import matplotlib.pyplot as plt
+mz = feature[3]
+ci_ppm = feature[9]
+plt.errorbar([0], [mz], yerr=[[ci_ppm],[ci_ppm]], fmt='o')
+plt.ylabel('m/z (Da)')
+plt.title('MS2 feature confidence interval (ppm scaled)')
+plt.show()
+```

--- a/documentation/Functions/ms2_peakStats_safe.md
+++ b/documentation/Functions/ms2_peakStats_safe.md
@@ -1,0 +1,66 @@
+---
+title: ms2_peakStats_safe
+kind: function
+source: Functions/ms2_peakStats_safe.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_peakStats_safe` wraps [`ms2_peak_stats`](./ms2_peak_stats.md) with exception handling and logging. When a Gaussian fit fails (e.g., insufficient points or singular matrices), it records the offending spectrum in `LogFileName` via [`WriteLog`](./WriteLog.md) and returns an empty list, allowing [`ms2_spectrum`](./ms2_spectrum.md) to skip the problematic window without crashing.
+
+## Code
+```python
+from ms2_peak_stats import *
+from WriteLog import *
+def ms2_peakStats_safe(RawSpectrum,DataSetName,ms_id,mz,TotalInt,LogFileName,mz_std=2e-3,stdDistance=3,minSignals=5,MaxCount=3,minInt=1e3,Points_for_regression=4,alpha=0.01):
+    while True:
+        try:
+            peak_stats=ms2_peak_stats(RawSpectrum=RawSpectrum,mz=mz,mz_std=mz_std,stdDistance=stdDistance,minSignals=minSignals,MaxCount=MaxCount,minInt=minInt,Points_for_regression=Points_for_regression)
+            return peak_stats
+        except:
+            Parameters=[DataSetName,ms_id,mz,mz_std,stdDistance,minSignals,MaxCount,minInt,Points_for_regression,alpha]
+            WriteLog(RawSpectrum=RawSpectrum,Parameters=Parameters,TotalInt=TotalInt,LogFileName=LogFileName)
+            return []
+```
+
+## Key operations
+- Repeats the call to [`ms2_peak_stats`](./ms2_peak_stats.md) once; on any exception it writes a diagnostic entry and exits.
+- Captures important context (dataset, scan ID, target m/z, thresholds) and stores it alongside the raw spectrum for future debugging.
+- Returns either the fitted peak stats (length ≥ 9 array) or an empty list so callers can decide how to proceed.
+
+## Parameters
+- `RawSpectrum`: see [`RawSpectrum`](../Variables/RawSpectrum.md).
+- `DataSetName`, `ms_id`: identifiers included in the log entry.
+- `mz`, `mz_std`, `stdDistance`: Gaussian window definitions.
+- `minSignals`, `MaxCount`, `minInt`, `Points_for_regression`, `alpha`: fitting controls forwarded to `ms2_peak_stats` or recorded in the log.
+- `TotalInt`: used by [`WriteLog`](./WriteLog.md) to assess spectrum quality.
+- `LogFileName`: CSV/Excel file collecting failed fits.
+
+## Input
+- Called from [`ms2_spectrum`](./ms2_spectrum.md) with the current `RawSpectrum` slice.
+
+## Output
+- Either the result of [`ms2_peak_stats`](./ms2_peak_stats.md) or `[]` (failure).
+
+## Functions
+- [`ms2_peak_stats`](./ms2_peak_stats.md)
+- [`WriteLog`](./WriteLog.md)
+
+## Called by
+- [`ms2_spectrum`](./ms2_spectrum.md)
+
+## Examples
+```python
+from Functions.ms2_peakStats_safe import ms2_peakStats_safe
+import numpy as np
+
+raw = np.array([[150.0, 1e4], [150.01, 8e3], [150.02, 3e3]])
+peak = ms2_peakStats_safe(raw, 'Sample_A', ms_id=10, mz=150.01,
+                          LogFileName='ms2.log', TotalInt=raw[:,1].sum(),
+                          minSignals=3, minInt=1e3)
+if len(peak) == 0:
+    print('Fit failed, check ms2.log for details')
+else:
+    print('Peak center:', peak[0])
+```
+This snippet demonstrates how the wrapper prevents the caller from crashing when `ms2_peak_stats` raises an exception.

--- a/documentation/Functions/ms2_peak_stats.md
+++ b/documentation/Functions/ms2_peak_stats.md
@@ -1,0 +1,53 @@
+---
+title: ms2_peak_stats
+kind: function
+source: Functions/ms2_peak_stats.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_peak_stats` extracts a fragment-specific window from a raw MS2 spectrum via [`ms2Peak`](./ms2Peak.md), refines it with [`Normal_Fit`](./Normal_Fit.md), and calculates confidence intervals. It is the core analytical routine wrapped by [`ms2_peakStats_safe`](./ms2_peakStats_safe.md).
+
+## Code
+```python
+from scipy import stats
+from ms2Peak import *
+from Normal_Fit import *
+def ms2_peak_stats(RawSpectrum,mz,mz_std=2e-3,stdDistance=3,minSignals=5,MaxCount=3,minInt=1e3,Points_for_regression=4,alpha=0.01):
+    PeakData_and_Stats=ms2Peak(RawSpectrum=RawSpectrum,mz=mz,mz_std=mz_std,stdDistance=stdDistance,minSignals=minSignals,MaxCount=MaxCount,minInt=minInt,Points_for_regression=Points_for_regression)
+    if len(PeakData_and_Stats)==0:
+        return []
+    NormalParameters=Normal_Fit(PeakData_and_Stats=PeakData_and_Stats)
+    Nsignals=len(PeakData_and_Stats[0][:,0])
+    PeakData=PeakData_and_Stats[0]
+    mz=NormalParameters[0]
+    mz_std=NormalParameters[1]
+    min_mz=[np.min(PeakData[:,0])]
+    max_mz=[np.max(PeakData[:,0])]
+    tref=stats.t.interval(1-alpha, Nsignals-1)[1]
+    ConfidenceIntervalDa=[tref*mz_std/np.sqrt(Nsignals)]
+    ConfidenceInterval=[tref*mz_std/np.sqrt(Nsignals)/mz*1e6]
+    peak_stats=NormalParameters+[Nsignals]+ConfidenceIntervalDa+ConfidenceInterval+min_mz+max_mz
+    return peak_stats
+```
+
+## Key operations
+- Calls [`ms2Peak`](./ms2Peak.md) to collect intensity/RT data around `mz`.
+- Fits a Gaussian with [`Normal_Fit`](./Normal_Fit.md).
+- Computes confidence intervals exactly like [`ms2_features_stats`](./ms2_features_stats.md).
+
+## Parameters
+- `RawSpectrum`: MS2 array.
+- `mz`, `mz_std`, `stdDistance`: define the window.
+- `minSignals`, `MaxCount`, `minInt`, `Points_for_regression`, `alpha`: quality controls and confidence settings.
+
+## Output
+- List `[mz, mz_std, I_total, r², Nsignals, CI_Da, CI_ppm, min_mz, max_mz]`.
+
+## Called by
+- [`ms2_peakStats_safe`](./ms2_peakStats_safe.md)
+
+## Example
+```python
+peak_stats = ms2_peak_stats(RawSpectrum, mz=150.02, minSignals=5)
+```

--- a/documentation/Functions/ms2_spectrum.md
+++ b/documentation/Functions/ms2_spectrum.md
@@ -1,0 +1,105 @@
+---
+title: ms2_spectrum
+kind: function
+source: Functions/ms2_spectrum.py
+last_updated: 2025-02-14
+---
+
+## Description
+`ms2_spectrum` cleans a raw MS2 profile (`RawSpectrum`), iteratively fits Gaussian fragment peaks using [`ms2_peakStats_safe`](./ms2_peakStats_safe.md), and returns a sorted fragment table enriched with relative intensities. Scientifically, it enforces quality metrics (minimum signals, relative intensity coverage, Gaussian goodness-of-fit) so that only structurally interpretable fragments seed the MS2-first workflow.
+
+**Math notes**  
+Each fragment peak is estimated with Gaussian statistics (`mz`, `mz_std`, `Intensity`) and a quality score. After all peaks are extracted, the function appends relative intensity percentages: \(I_{\text{rel}} = 100 \times I_i / I_{\text{max}}\).
+
+## Code
+```python
+import numpy as np
+from ms2_peakStats_safe import *
+def ms2_spectrum(RawSpectrum,DataSetName,ms_id,LogFileName,mz_std=2e-3,stdDistance=3,minQuality=100,minInt=1e2,minSignals=4,MaxCount=3,Points_for_regression=4,minPeaks=2,sort=2,as_des=-1):
+    RawSpectrum=RawSpectrum[RawSpectrum[:,1]>0,:]
+    TotalInt=sum(RawSpectrum[:,1])
+    if len(RawSpectrum[:,0])<minSignals:
+        return []
+    Spectrum=[]
+    while True:
+        maxInt=np.max(RawSpectrum[:,1])
+        if maxInt<minInt:
+            break
+        maxIntLoc=RawSpectrum[:,1]==maxInt
+        mz_maxInt=RawSpectrum[maxIntLoc,0][0]
+        peak_stats=ms2_peakStats_safe(RawSpectrum=RawSpectrum,DataSetName=DataSetName,ms_id=ms_id,mz=mz_maxInt,LogFileName=LogFileName,TotalInt=TotalInt,mz_std=mz_std,stdDistance=stdDistance,minSignals=minSignals,MaxCount=MaxCount,minInt=minInt,Points_for_regression=Points_for_regression)
+        if len(peak_stats)>0:
+            min_mz_peak=peak_stats[7]
+            max_mz_peak=peak_stats[8]
+            Spectrum.append(peak_stats)
+        else:
+            min_mz_peak=mz_maxInt-mz_std*stdDistance
+            max_mz_peak=mz_maxInt+mz_std*stdDistance
+        Latest_peakFilter=(RawSpectrum[:,0]<min_mz_peak)|(RawSpectrum[:,0]>max_mz_peak)
+        RawSpectrum=RawSpectrum[Latest_peakFilter,:]
+        if len(RawSpectrum[:,0])<minSignals:
+            break
+    if len(Spectrum)<minPeaks:
+        return []
+    Spectrum=np.array(Spectrum)
+    Spectrum=Spectrum[(as_des*Spectrum[:,sort]).argsort(),:]
+    RelIntVec=(Spectrum[:,2]/Spectrum[0,2]*100).reshape(-1, 1)
+    Spectrum=np.hstack((Spectrum,RelIntVec))
+    QualityFilter=Spectrum[:,6]<minQuality
+    Spectrum=Spectrum[QualityFilter,:]
+    return Spectrum
+```
+
+## Key operations
+- Removes non-positive intensities to avoid log/ratio errors.
+- Iteratively centers a Gaussian window around the highest remaining peak and calls [`ms2_peakStats_safe`](./ms2_peakStats_safe.md) for robust fitting/logging.
+- Removes the processed m/z window from the working spectrum to prevent duplicate detections.
+- Enforces a minimum number of peaks and sorts the fragment list by `sort` column (default intensity) and `as_des` ordering.
+- Appends relative intensity percentages and filters by `minQuality` to keep reliable fragments.
+
+## Parameters
+- `RawSpectrum (np.ndarray)`: see [`RawSpectrum`](../Variables/RawSpectrum.md).
+- `DataSetName (str)`, `ms_id (int)`, `LogFileName (str)`: identifiers for logging exceptions.
+- `mz_std (float)`, `stdDistance (float)`: Gaussian width and integration span.
+- `minQuality (float)`: threshold on the quality metric returned by `ms2_peakStats_safe` (lower is better in this implementation).
+- `minInt (float)`, `minSignals (int)`: intensity and point-count filters before fitting.
+- `MaxCount`, `Points_for_regression`: control polynomial regression or peak-shape estimation inside helper functions.
+- `minPeaks (int)`: ensures at least two fragments remain, enabling cosine similarity downstream.
+- `sort (int)`, `as_des (±1)`: determine sorting column and ascending/descending order.
+
+## Input
+- [`RawSpectrum`](../Variables/RawSpectrum.md)
+- Metadata strings used for logging.
+
+## Output
+- numpy array of fragment statistics including relative intensity (%). Each row originates from [`ms2_peakStats_safe`](./ms2_peakStats_safe.md).
+
+## Functions
+- [`ms2_peakStats_safe`](./ms2_peakStats_safe.md)
+
+## Called by
+- Higher-level MS2 processing pipelines before redundancy clustering or fragment export.
+
+## Examples
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from Functions.ms2_spectrum import ms2_spectrum
+
+raw = np.array([
+    [150.0234, 1.2e4],
+    [150.0240, 5.2e4],
+    [200.1111, 7.1e4],
+    [200.1120, 8.3e4],
+    [250.0500, 2.0e4]
+])
+# Mock ms2_peakStats_safe by patching if necessary during testing
+spectrum = ms2_spectrum(raw, 'Sample_A', ms_id=42, LogFileName='ms2.log', minInt=5e3, minSignals=3, minPeaks=1)
+if len(spectrum) > 0:
+    plt.bar(np.arange(spectrum.shape[0]), spectrum[:,2])
+    plt.xlabel('Fragment index')
+    plt.ylabel('Intensity (a.u.)')
+    plt.title('Accepted fragments after ms2_spectrum')
+    plt.show()
+```
+When `ms2_peakStats_safe` is available, this code plots the intensities of the surviving fragments.

--- a/documentation/Functions/mzPeak.md
+++ b/documentation/Functions/mzPeak.md
@@ -1,0 +1,50 @@
+---
+title: mzPeak
+kind: function
+source: Functions/mzPeak.py
+last_updated: 2025-02-14
+---
+
+## Description
+`mzPeak` extracts an MS1 peak window from `DataSet` around a target m/z. It repeatedly calls `Find_mzPeak` to collect data and adjusts the Gaussian width using `mz_Gauss_std` until convergence. The output is consumed by [`ms2_features_stats`](./ms2_features_stats.md) and [`ms2_peak_stats`](./ms2_peak_stats.md).
+
+## Code
+```python
+from Find_mzPeak import *
+from mz_Gauss_std import *
+def mzPeak(DataSet,spectrum_idVec,mz,mz_std=2e-3,stdDistance=3,count=0,MaxCount=3,Points_for_regression=5,minSignals=7,minInt=1e3):
+    PeakData_and_meta=Find_mzPeak(DataSet=DataSet,spectrum_idVec=spectrum_idVec,mz=mz,mz_std=mz_std,stdDistance=stdDistance,MaxCount=MaxCount,minInt=minInt)
+    if len(PeakData_and_meta)==0:
+        return []
+    PeakData=PeakData_and_meta[0]
+    spectrum_id=PeakData_and_meta[1]
+    GaussStats=mz_Gauss_std(PeakData,Points_for_regression=Points_for_regression)
+    New_mz_std=GaussStats[1]
+    if New_mz_std>mz_std and count<MaxCount:
+        PeakData=mzPeak(DataSet=DataSet,spectrum_idVec=spectrum_idVec,mz=mz,mz_std=New_mz_std,count=count+1,minInt=minInt)[0]
+    PeakData_and_Stats=[PeakData,GaussStats,spectrum_id]
+    return PeakData_and_Stats
+```
+
+## Key operations
+- Retrieves raw data from the closest MS1 scans using `spectrum_idVec`.
+- Estimates Gaussian parameters via `mz_Gauss_std` and recursively widens the window if the new standard deviation exceeds the previous one.
+
+## Parameters
+- `DataSet`: MS1 iterable.
+- `spectrum_idVec`: list of MS1 scan indices from [`closest_ms1_spec`](./closest_ms1_spec.md).
+- `mz`, `mz_std`, `stdDistance`: extraction window.
+- `MaxCount`: recursion limit for widening the window.
+- `Points_for_regression`, `minSignals`, `minInt`: controls for Gaussian estimation.
+
+## Output
+- `[PeakData, GaussStats, spectrum_id]` where `PeakData` is an array of `[m/z, intensity]` and `GaussStats` contains initial Gaussian parameters.
+
+## Called by
+- [`ms2_features_stats`](./ms2_features_stats.md)
+- [`ms2_peak_stats`](./ms2_peak_stats.md)
+
+## Example
+```python
+peak_bundle = mzPeak(DataSet, spectrum_idVec=[10020,10021], mz=300.123)
+```

--- a/documentation/Functions/mz_Gauss_std.md
+++ b/documentation/Functions/mz_Gauss_std.md
@@ -1,0 +1,53 @@
+---
+title: mz_Gauss_std
+kind: function
+source: Functions/mz_Gauss_std.py
+last_updated: 2025-02-14
+---
+
+## Description
+`mz_Gauss_std` estimates Gaussian parameters (centroid, standard deviation, intercept, r², total area) from raw peak data by performing a linear regression on log-intensity vs. squared deviation. Used by [`ms2Peak`](./ms2Peak.md) and [`mzPeak`](./mzPeak.md) to initialize Gaussian fits.
+
+## Code
+```python
+from scipy import stats
+import numpy as np
+def mz_Gauss_std(PeakData,Points_for_regression=4):
+    PeakData=PeakData[PeakData[:,1]>0,:].copy()
+    maxInt=np.max(PeakData[:,1])
+    maxInt_Loc=np.where(PeakData[:,1]==maxInt)[0][0]
+    mz_maxInt=PeakData[maxInt_Loc,0]
+    mz_DifVec=np.abs(PeakData[:,0]-mz_maxInt)
+    PeakData=PeakData[mz_DifVec.argsort(),:]
+    Closest_PeakData=PeakData[:Points_for_regression,:]
+    log_Int_Vec=np.log(Closest_PeakData[:,1]/maxInt)
+    Variance_mz_vec=(Closest_PeakData[:,0]-mz_maxInt)**2
+    X=log_Int_Vec
+    Y=Variance_mz_vec
+    reg=stats.linregress(X,Y)
+    m=reg[0]
+    b=reg[1]
+    r2=reg[2]**2
+    mz_std=np.sqrt(-m/2)
+    sqrt2pi=2.5066282746310002 #np.sqrt(np.pi*2)
+    I_total=maxInt*mz_std*sqrt2pi
+    GaussStats=[mz_maxInt,mz_std,b,r2,I_total]
+    return GaussStats
+```
+
+## Key operations
+- Selects the `Points_for_regression` closest points to the most intense fragment.
+- Uses the Gaussian log-linear relationship to estimate variance.
+- Returns both width and approximated total intensity for downstream fitting.
+
+## Output
+- `GaussStats = [mz_centroid, mz_std, intercept, r², I_total]`
+
+## Called by
+- [`ms2Peak`](./ms2Peak.md)
+- [`mzPeak`](./mzPeak.md)
+
+## Example
+```python
+stats = mz_Gauss_std(PeakData, Points_for_regression=5)
+```

--- a/documentation/Functions/mz_RT_spectrum_filter.md
+++ b/documentation/Functions/mz_RT_spectrum_filter.md
@@ -1,0 +1,79 @@
+---
+title: mz_RT_spectrum_filter
+kind: function
+source: Functions/mz_RT_spectrum_filter.py
+last_updated: 2025-02-14
+---
+
+## Description
+`mz_RT_spectrum_filter` inspects a single spectrum object, verifies that it is MS2, falls within RT/m/z bounds, and appends its summary metrics to [`SummMS2`](../Variables/SummMS2.md). It is the per-spectrum worker used by [`AllMS2Data`](./AllMS2Data.md).
+
+## Code
+```python
+import numpy as np
+def mz_RT_spectrum_filter(SpectralSignals,SummMS2,min_RT,max_RT,min_mz,max_mz,spectrum_id):
+    MSLevel=SpectralSignals.getMSLevel()
+    if MSLevel!=2:
+        return SummMS2
+    RT=SpectralSignals.getRT()
+    if RT<min_RT or RT>max_RT:
+        return SummMS2
+    Precursor=SpectralSignals.getPrecursors()[0]
+    MZ=Precursor.getMZ()
+    if MZ<min_mz or MZ>max_mz:
+        return SummMS2
+    Spectrum=np.array(SpectralSignals.get_peaks()).T
+    maxInt=np.max(Spectrum[:,1])
+    TotalInt=np.sum(Spectrum[:,1])
+    AllInt=np.sum(Spectrum[:,1])
+    maxInt_frac=maxInt/AllInt
+    SummSpec=np.array([MZ,RT,spectrum_id,TotalInt,maxInt_frac])
+    SummMS2.append(SummSpec)
+    return SummMS2
+```
+
+## Key operations
+- Rejects non-MS2 scans immediately, ensuring MS1 spectra never enter the MS2 summary.
+- Applies rectangular RT/m/z filters using instrument metadata.
+- Extracts peak arrays via `get_peaks()`, computes `TotalInt` and `maxInt_frac`, and appends them with the running `spectrum_id`.
+
+## Parameters
+- `SpectralSignals`: spectrum object from [`DataSet`](../Variables/DataSet.md).
+- `SummMS2 (list)`: accumulator for MS2 summaries.
+- `min_RT`, `max_RT` (seconds) and `min_mz`, `max_mz` (Da): bounds.
+- `spectrum_id (int)`: index assigned while iterating through the raw file.
+
+## Input
+- Receives `SpectralSignals` and current `SummMS2` from [`AllMS2Data`](./AllMS2Data.md).
+
+## Output
+- Returns the updated list `SummMS2` (later converted to numpy array).
+
+## Functions
+- Uses numpy for intensity calculations.
+
+## Called by
+- [`AllMS2Data`](./AllMS2Data.md).
+
+## Examples
+```python
+from Functions.mz_RT_spectrum_filter import mz_RT_spectrum_filter
+
+class MockSpectrum:
+    def __init__(self, level, rt, precursor_mz, peaks):
+        self._level, self._rt, self._precursor_mz, self._peaks = level, rt, precursor_mz, peaks
+    def getMSLevel(self):
+        return self._level
+    def getRT(self):
+        return self._rt
+    def getPrecursors(self):
+        return [type('P', (), {'getMZ': lambda self: self})(self._precursor_mz)]
+    def get_peaks(self):
+        return self._peaks
+
+summ = []
+mock = MockSpectrum(2, 120.5, 300.12, [[300.12, 5e4], [301.0, 1e3]])
+summ = mz_RT_spectrum_filter(mock, summ, 100, 200, 250, 400, spectrum_id=10)
+print(summ[-1])  # [300.12, 120.5, 10, total_int, max_int_frac]
+```
+This example shows how a single spectrum is validated and summarized before aggregation.

--- a/documentation/Functions/r2_Gauss.md
+++ b/documentation/Functions/r2_Gauss.md
@@ -1,0 +1,36 @@
+---
+title: r2_Gauss
+kind: function
+source: Functions/r2_Gauss.py
+last_updated: 2025-02-14
+---
+
+## Description
+Computes the coefficient of determination (r²) between observed chromatogram intensities and the Gaussian model returned by [`GaussianPeak`](./GaussianPeak.md). Used to assess fit quality in [`Normal_Fit`](./Normal_Fit.md).
+
+## Code
+```python
+import numpy as np
+from GaussianPeak import *
+def r2_Gauss(PeakData,GaussianParameters):
+    mz=GaussianParameters[0]
+    mz_std=GaussianParameters[1]
+    I_total=GaussianParameters[2]
+    Gaussian_Int=GaussianPeak(PeakData[:,0],mz,mz_std,I_total)
+    I_mean=np.mean(PeakData[:,1])
+    SS_tot=np.sum((PeakData[:,1]-I_mean)**2)
+    SS_res=np.sum((Gaussian_Int-PeakData[:,1])**2)
+    r2=1-SS_res/SS_tot
+    return [r2]
+```
+
+## Output
+- List `[r²]` appended to fitted parameter lists.
+
+## Called by
+- [`Normal_Fit`](./Normal_Fit.md)
+
+## Example
+```python
+r2 = r2_Gauss(PeakData, GaussianParameters)[0]
+```

--- a/documentation/GLOSSARY.md
+++ b/documentation/GLOSSARY.md
@@ -1,0 +1,67 @@
+---
+title: ms2Gauss Glossary
+kind: meta
+source: documentation/GLOSSARY.md
+last_updated: 2025-02-14
+---
+
+# Glossary
+
+Short definitions for recurring scientific and computational terms in ms2Gauss. Each entry links to deeper theory in [`DEFINITIONS.md`](./DEFINITIONS.md) or to the relevant function/variable docs.
+
+## m/z
+Mass-to-charge ratio of ions detected in Orbitrap spectra. It sets the horizontal axis for both MS1 and MS2 data and is modeled with Gaussian distributions to capture high-resolution peak shapes.
+
+## Orbitrap
+A Fourier-transform mass analyzer that measures ion oscillations as image currents. ms2Gauss assumes Orbitrap-level resolving power when setting Gaussian widths and ppm-level confidence intervals.
+
+## MS1
+Survey (precursor) scans containing intact ions. ms2Gauss uses MS1 chromatograms to refine MS2-derived features through [`ms2_features_stats`](./Functions/ms2_features_stats.md) and [`feat_ms2_Gauss`](./Functions/feat_ms2_Gauss.md).
+
+## MS2
+Fragmentation scans acquired after MS1. They anchor the workflow: peaks are first selected from MS2 summaries via [`AllMS2Data`](./Functions/AllMS2Data.md) and [`ms2_SpectralRedundancy`](./Functions/ms2_SpectralRedundancy.md) before MS1 refinement occurs.
+
+## Retention time (RT)
+Chromatographic elution time in seconds. RT windows bound chromatographic umbrellas and appear in tables such as [`SummMS2`](./Variables/SummMS2.md) and [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md).
+
+## Spectral redundancy
+Multiple MS2 spectra acquired for the same precursor. It is mitigated with cosine similarity clustering in [`ms2_SpectralRedundancy`](./Functions/ms2_SpectralRedundancy.md).
+
+## Gaussian peak
+A model of ion intensity as a normal distribution over m/z or RT:
+\[
+I(\text{axis}) = \frac{I_{\text{total}}}{\sigma\sqrt{2\pi}} \exp\left( -\frac{(x-\mu)^2}{2\sigma^2} \right)
+\]
+Implemented in [`GaussianPeak`](./Functions/GaussianPeak.md) and used throughout MS1/MS2 fits.
+
+## ppm (parts per million)
+Unit for mass error: \(\text{ppm} = 10^6 (m_{\text{measured}}-m_{\text{true}})/m_{\text{true}}\). Confidence intervals in [`MS2_Features`](./Variables/MS2_Features.md) are reported in ppm.
+
+## Cosine similarity
+Similarity metric for MS2 fragment vectors. Used inside [`ms2_SpectralSimilarityClustering`](./Functions/ms2_SpectralSimilarityClustering.md) to build redundancy modules.
+
+## Chromatographic umbrella
+RT window covering all detections for a feature. Derived from `min_RT`/`max_RT` columns in [`SummMS2`](./Variables/SummMS2.md) and propagated to [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md).
+
+## Feature module
+Cluster of spectra/features representing the same compound across samples. Created by [`Cluster_ms2_Features`](./Functions/Cluster_ms2_Features.md) or [`ms2_SpectralSimilarityClustering`](./Functions/ms2_SpectralSimilarityClustering.md).
+
+## Genetic algorithm (GA)
+Evolutionary strategy used in ms2Gauss for chromatogram deconvolution and parameter fitting. Populations, mutation rates, and fitness functions live in `Functions/` but share the Gaussian modeling assumptions summarized in [`DEFINITIONS.md`](./DEFINITIONS.md#genetic-algorithms-for-chromatograms).
+
+## Alignment matrix
+Table aligning MS2-derived features across samples, e.g., [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md) and [`AlignedSamples_RT_DF`](./Variables/AlignedSamples_RT_DF.md).
+
+## Confidence interval (CI)
+Statistical range estimated for m/z (Da and ppm) via Student’s t-distribution as shown in [`ms2_features_stats`](./Functions/ms2_features_stats.md).
+
+## SummMS2
+MS2 summary table after redundancy resolution. Described in detail in [`SummMS2`](./Variables/SummMS2.md).
+
+## MS2_Features
+Gaussian-refined feature table produced by [`feat_ms2_Gauss`](./Functions/feat_ms2_Gauss.md). Columns include fitted m/z, RT, intensities, uncertainties, and provenance metadata.
+
+## Alignment tolerance
+Pair of parameters (`mz_Tol`, `RT_tol`) controlling how features are grouped. Tuned in [`Features_ms2_SamplesAligment`](./Functions/Features_ms2_SamplesAligment.md).
+
+Use this glossary whenever a documentation page references foundational terminology.

--- a/documentation/IMPROVEMENT_PLAN.md
+++ b/documentation/IMPROVEMENT_PLAN.md
@@ -1,0 +1,33 @@
+---
+title: ms2Gauss Improvement Plan
+kind: meta
+source: documentation/IMPROVEMENT_PLAN.md
+last_updated: 2025-02-14
+---
+
+# Improvement Plan
+
+Roadmap tracking conceptual refinements, computational efficiency, and missing building blocks.
+
+## 1. Conceptual enhancements
+
+1. **Explicit MS2-first rationale in docs.** Expand [`documentation/Functions/ms2_spectrum.md`](./Functions/ms2_spectrum.md) and [`documentation/Variables/SummMS2.md`](./Variables/SummMS2.md) with comparisons to MS1-first workflows and cite supporting references to strengthen scientific framing.
+2. **Noise modeling and detection limits.** Introduce a documented parameter set (`NoiseThresholds` table) that records instrument-specific noise estimates for both MS1 and MS2 to rationalize `minSignals`, `minInt`, and `NoiseTresList` used in chromatogram modules.
+3. **Experimental design filters.** Extend [`Features_ms2_SamplesAligment`](./Functions/Features_ms2_SamplesAligment.md) documentation with strategies for blank subtraction, replicate consistency, and isotopic labeling, referencing tables such as [`All_FeaturesTable`](./Variables/All_FeaturesTable.md).
+4. **Uncertainty propagation to alignment.** Propagate ppm/RT confidence intervals into [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md) by averaging variances instead of simple means; document formulas in [`DEFINITIONS.md`](./DEFINITIONS.md).
+
+## 2. Computational efficiency
+
+1. **Vectorized redundancy filtering.** Replace Python loops inside [`ms2_SpectralRedundancy`](./Functions/ms2_SpectralRedundancy.md) with numpy/pandas group-bys to reduce runtime on large summary spreadsheets.
+2. **Batch MS1 extraction.** Cache `closest_ms1_spec` results across features to avoid repeated searches through [`MS1IDVec`](./Variables/MS1IDVec.md) during [`feat_ms2_Gauss`](./Functions/feat_ms2_Gauss.md).
+3. **Parallel Gaussian fits.** Use multiprocessing or joblib to run [`ms2_features_stats`](./Functions/ms2_features_stats.md) on feature batches, respecting reproducibility by seeding RNGs used in GA components.
+4. **Sparse alignment storage.** When many samples are zero for a feature, store [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md) as a sparse matrix or parquet file to save disk space.
+
+## 3. Missing or orphaned components
+
+1. **`ms2_peakStats_safe` deep dive.** Create a full doc for [`ms2_peakStats_safe`](./Functions/ms2_peakStats_safe.md) describing how it stabilizes fragment peak estimation, since many upstream functions depend on it.
+2. **Chromatographic GA tutorial.** Extract notebook logic into a `run_gaussian_chromatogram_fit` helper documented in `documentation/Functions/` so users can reproduce GA-based deconvolution without reading raw notebooks.
+3. **Parameter tables.** Document CSV files controlling bounds (e.g., `ParametersTable.csv`, `MaxAtomicSubscripts.csv`) under `documentation/Variables/` to clarify chemical constraints.
+4. **Reference integration.** Summaries of the 11 reference PDFs should be added to a future `documentation/REFERENCES.md`, linking each method to specific literature citations.
+
+Track progress by checking off each bullet once the associated docs or code updates are merged.

--- a/documentation/INDEX.md
+++ b/documentation/INDEX.md
@@ -1,0 +1,63 @@
+---
+title: ms2Gauss Documentation Index
+kind: meta
+source: documentation/INDEX.md
+last_updated: 2025-02-14
+---
+
+# Documentation Index
+
+Overview of all documentation assets created during this iteration. Links follow the ms2Gauss workflow order.
+
+## Workflow snapshot
+
+```
+Raw Orbitrap files → [AllMS2Data](./Functions/AllMS2Data.md)
+                  → [ms2_SpectralRedundancy](./Functions/ms2_SpectralRedundancy.md)
+                  → [SummMS2](./Variables/SummMS2.md)
+                  → [ms2_features_stats](./Functions/ms2_features_stats.md)
+                  → [feat_ms2_Gauss](./Functions/feat_ms2_Gauss.md)
+                  → [MS2_Features](./Variables/MS2_Features.md)
+                  → [Features_ms2_SamplesAligment](./Functions/Features_ms2_SamplesAligment.md)
+                  → [AlignedSamplesDF](./Variables/AlignedSamplesDF.md)
+```
+
+## Functions
+
+| Function | Summary |
+| --- | --- |
+| [AllMS2Data](./Functions/AllMS2Data.md) | Streams MS2 profile data and builds [`SummMS2`](./Variables/SummMS2.md) arrays by applying RT/m/z filters via [`mz_RT_spectrum_filter`](./Functions/mz_RT_spectrum_filter.md). |
+| [ms2_spectrum](./Functions/ms2_spectrum.md) | Iteratively extracts Gaussian MS2 fragment peaks with [`ms2_peakStats_safe`](./Functions/ms2_peakStats_safe.md) and enforces quality thresholds. |
+| [ms2_SpectralRedundancy](./Functions/ms2_SpectralRedundancy.md) | Clusters redundant MS2 detections per sample using cosine similarity. |
+| [ms2_features_stats](./Functions/ms2_features_stats.md) | Links MS2 detections to MS1 chromatograms, fits Gaussian centroids, and computes ppm confidence intervals. |
+| [feat_ms2_Gauss](./Functions/feat_ms2_Gauss.md) | Aggregates per-detection stats into a full [`MS2_Features`](./Variables/MS2_Features.md) table. |
+| [Features_ms2_SamplesAligment](./Functions/Features_ms2_SamplesAligment.md) | Aligns MS2-derived features across samples, producing [`AlignedSamplesDF`](./Variables/AlignedSamplesDF.md) and [`AlignedSamples_RT_DF`](./Variables/AlignedSamples_RT_DF.md). |
+| [mz_RT_spectrum_filter](./Functions/mz_RT_spectrum_filter.md) | **Stub.** Documents how MS2 profile arrays are filtered by RT/m/z windows. |
+| [ms2_peakStats_safe](./Functions/ms2_peakStats_safe.md) | **Stub.** Describes fragment peak fitting safeguards used by [`ms2_spectrum`](./Functions/ms2_spectrum.md). |
+| [closest_ms1_spec](./Functions/closest_ms1_spec.md) | **Stub.** Explains MS1 spectrum selection around an MS2 event. |
+| [Normal_Fit](./Functions/Normal_Fit.md) | **Stub.** Captures Gaussian fitting of MS1 peak windows. |
+| [Cluster_ms2_Features](./Functions/Cluster_ms2_Features.md) | **Stub.** Placeholder for clustering features across MS2 detections. |
+| [ms2_SpectralSimilarityClustering](./Functions/ms2_SpectralSimilarityClustering.md) | **Stub.** Placeholder describing cosine-based MS2 clustering. |
+| [JoiningFeatures](./Functions/JoiningFeatures.md) | **Stub.** Placeholder summarizing concatenation of per-sample feature tables. |
+
+## Variables and tables
+
+| Variable/Table | Summary |
+| --- | --- |
+| [DataSet](./Variables/DataSet.md) | Container of MS1 or MS2 spectra (list of numpy arrays). |
+| [RawSpectrum](./Variables/RawSpectrum.md) | Individual MS2 spectrum array with `[m/z, intensity]` columns. |
+| [SummMS2](./Variables/SummMS2.md) | Redundancy-resolved MS2 table with umbrellas and provenance. |
+| [MS1IDVec](./Variables/MS1IDVec.md) | Mapping of MS1 scan indices to RT for linking MS2 events back to chromatograms. |
+| [MS2_Features](./Variables/MS2_Features.md) | Gaussian-refined MS2 feature catalog with ppm CI columns. |
+| [All_FeaturesTable](./Variables/All_FeaturesTable.md) | Stacked per-sample feature table used before alignment. |
+| [AlignedSamplesDF](./Variables/AlignedSamplesDF.md) | Feature × sample intensity matrix with umbrella metadata. |
+| [AlignedSamples_RT_DF](./Variables/AlignedSamples_RT_DF.md) | Same as `AlignedSamplesDF` but storing RT for each sample column. |
+
+## Meta references
+
+- [Glossary](./GLOSSARY.md)
+- [Definitions](./DEFINITIONS.md)
+- [Improvement plan](./IMPROVEMENT_PLAN.md)
+- [Agents](./Agents.md)
+
+Use this index to navigate the evolving book-style documentation.

--- a/documentation/Variables/AlignedSamplesDF.md
+++ b/documentation/Variables/AlignedSamplesDF.md
@@ -1,0 +1,51 @@
+---
+title: AlignedSamplesDF
+kind: table
+source: Variables/AlignedSamplesDF
+last_updated: 2025-02-14
+---
+
+## Description
+`AlignedSamplesDF` is the pandas DataFrame produced by [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md). Rows correspond to aligned MS2-derived features, while columns contain umbrella metadata plus one intensity column per sample. It facilitates cross-sample comparisons and downstream filtering.
+
+## Code
+```python
+Columns = ['mz_(Da)','mz_std_(Da)','mz_CI_(Da)','mz_CI_(ppm)',
+           'RT_(s)','min_RT_(s)','max_RT_(s)','Sample_A','Sample_B']
+AlignedSamplesDF = pd.DataFrame([
+    [300.12345, 1.4e-03, 1.1e-04, 0.37, 245.6, 240.1, 248.3, 8.2e05, 7.9e05]
+], columns=Columns)
+```
+
+## Key operations
+- Columns 0–6 summarize the consensus Gaussian parameters across samples.
+- Sample columns (`Sample_A`, `Sample_B`, …) store per-sample intensities pulled from [`All_FeaturesTable`](./All_FeaturesTable.md).
+- Retention-time umbrellas (`min_RT`, `max_RT`) guide chromatographic comparisons and blank filtering.
+
+## Parameters / columns
+1. `mz_(Da)`, `mz_std_(Da)`: averaged precursor centroid and width.
+2. `mz_CI_(Da)`, `mz_CI_(ppm)`: averaged uncertainties.
+3. `RT_(s)`: average RT across contributing samples.
+4. `min_RT_(s)`, `max_RT_(s)`: umbrella bounds inherited from per-sample entries.
+5. `Sample_*` columns: intensities for each aligned sample.
+
+## Input
+- Created from [`All_FeaturesTable`](./All_FeaturesTable.md) after clustering modules returned by [`ms2_SpectralSimilarityClustering`](../Functions/ms2_SpectralSimilarityClustering.md).
+
+## Output
+- Exported to Excel when `saveAlignedTable=True`.
+- Serves as the canonical aligned matrix for downstream statistics (blank subtraction, treatment comparisons, etc.).
+
+## Functions
+- [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md)
+
+## Called by
+- Experimental filters (e.g., `Samples_AttributesFilter`) and visualization notebooks.
+
+## Example table
+
+| mz_(Da) | mz_std_(Da) | mz_CI_(ppm) | RT_(s) | min_RT_(s) | max_RT_(s) | Sample_A | Sample_B |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 300.12345 | 0.0014 | 0.37 | 245.6 | 240.1 | 248.3 | 8.2e05 | 7.9e05 |
+
+This layout allows quick inspection of feature intensities across multiple samples while retaining umbrella metadata.

--- a/documentation/Variables/AlignedSamples_RT_DF.md
+++ b/documentation/Variables/AlignedSamples_RT_DF.md
@@ -1,0 +1,46 @@
+---
+title: AlignedSamples_RT_DF
+kind: table
+source: Variables/AlignedSamples_RT_DF
+last_updated: 2025-02-14
+---
+
+## Description
+`AlignedSamples_RT_DF` mirrors [`AlignedSamplesDF`](./AlignedSamplesDF.md) but replaces per-sample intensity columns with the retention times observed in each sample. It is returned as the second element of [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md) to help diagnose chromatographic drifts.
+
+## Code
+```python
+Columns = ['mz_(Da)','mz_std_(Da)','mz_CI_(Da)','mz_CI_(ppm)',
+           'RT_(s)','min_RT_(s)','max_RT_(s)','Sample_A','Sample_B']
+AlignedSamples_RT_DF = pd.DataFrame([
+    [300.12345, 1.4e-03, 1.1e-04, 0.37, 245.6, 240.1, 248.3, 245.4, 246.0]
+], columns=Columns)
+```
+
+## Key operations
+- Shares metadata columns (0–6) with `AlignedSamplesDF`.
+- Sample columns store RTs pulled from [`All_FeaturesTable`](./All_FeaturesTable.md) column 2 during alignment.
+- Enables visualization of chromatographic shifts or umbrella violations without recomputing intensities.
+
+## Parameters / columns
+- Same interpretation as `AlignedSamplesDF`, except sample columns contain RT (seconds) instead of intensity.
+
+## Input
+- Created in lockstep with `AlignedSamplesDF` within [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md).
+
+## Output
+- Optionally exported as `RT_<timestamp>.xlsx` for quality-control notebooks.
+
+## Functions
+- [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md)
+
+## Called by
+- Alignment QC routines and chromatographic drift assessments.
+
+## Example table
+
+| mz_(Da) | RT_(s) | min_RT_(s) | max_RT_(s) | Sample_A (RT) | Sample_B (RT) |
+| --- | --- | --- | --- | --- | --- |
+| 300.12345 | 245.6 | 240.1 | 248.3 | 245.4 | 246.0 |
+
+The per-sample RT columns help verify that each detection falls inside the umbrella bounds.

--- a/documentation/Variables/All_FeaturesTable.md
+++ b/documentation/Variables/All_FeaturesTable.md
@@ -1,0 +1,50 @@
+---
+title: All_FeaturesTable
+kind: table
+source: Variables/All_FeaturesTable
+last_updated: 2025-02-14
+---
+
+## Description
+`All_FeaturesTable` is the vertical concatenation of per-sample `MS2_Features` exports. [`JoiningFeatures`](../Functions/JoiningFeatures.md) reads every feature spreadsheet inside a results folder, appends the sample index, and merges them into a single numpy array that still preserves the [`MS2_Features`](./MS2_Features.md) column order. This stacked table feeds the alignment stage.
+
+## Code
+```python
+All_FeaturesTable = np.array([
+    [18240, 10021, 245.6, 300.1234, 1.5e-03, 8.2e05, 0.997, 28,
+     1.2e-04, 0.40, 299.118, 301.129, 240.1, 248.3, 3, 7021, 0],
+    [18241, 10040, 247.0, 300.1236, 1.4e-03, 7.9e05, 0.993, 25,
+     1.4e-04, 0.47, 299.119, 301.130, 241.0, 249.0, 2, 7025, 1]
+])
+```
+
+## Key operations
+- Created by [`JoiningFeatures`](../Functions/JoiningFeatures.md) after filtering by `mz_min/max` and `RT_min/max`.
+- The last column (`sample_id`) tells [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md) which sample contributed each row.
+- Intensities (column 5) and RTs (column 2) are copied into aligned matrices for their respective samples.
+
+## Parameters / columns
+Columns 0–15 mirror [`MS2_Features`](./MS2_Features.md). Column 16 is new:
+- `sample_id`: zero-based index assigned by `JoiningFeatures`, also used to map onto column positions in alignment matrices.
+
+## Input
+- Built from per-sample feature spreadsheets stored under a results folder created by `feat_ms2_Gauss` or GA-based refinements.
+
+## Output
+- Consumed directly by [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md) and by cluster inspection notebooks.
+
+## Functions
+- [`JoiningFeatures`](../Functions/JoiningFeatures.md)
+- [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md)
+
+## Called by
+- Batch alignment pipelines when generating experiment-wide matrices.
+
+## Example table
+
+| ms2_id | ms1_id | RT_(s) | mz_(Da) | mz_std_(Da) | I_total_(a.u.) | Gauss_r2 | CI_(ppm) | sample_id |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 18240 | 10021 | 245.6 | 300.1234 | 0.0015 | 8.2e05 | 0.997 | 0.40 | 0 |
+| 18241 | 10040 | 247.0 | 300.1236 | 0.0014 | 7.9e05 | 0.993 | 0.47 | 1 |
+
+Only a subset of columns is shown; the actual array contains the full set from [`MS2_Features`](./MS2_Features.md).

--- a/documentation/Variables/DataSet.md
+++ b/documentation/Variables/DataSet.md
@@ -1,0 +1,66 @@
+---
+title: DataSet
+kind: variable
+source: Variables/DataSet
+last_updated: 2025-02-14
+---
+
+## Description
+`DataSet` is the iterable of Orbitrap spectra (MS1 or MS2) loaded from vendor files. Each element exposes `getMSLevel()`, `getRT()`, and `get_peaks()` so functions such as [`AllMS2Data`](../Functions/AllMS2Data.md) and [`ms2_features_stats`](../Functions/ms2_features_stats.md) can access intensities, retention times, and precursor metadata. Scientifically, it represents the raw experimental evidence before Gaussian modeling.
+
+## Code
+```python
+# Example DataSet composed of simplified spectrum objects
+class MockSpectrum:
+    def __init__(self, level, rt, peaks, precursor_mz=None):
+        self._level = level
+        self._rt = rt
+        self._peaks = peaks
+        self._precursor_mz = precursor_mz
+    def getMSLevel(self):
+        return self._level
+    def getRT(self):
+        return self._rt
+    def get_peaks(self):
+        return self._peaks
+    def getPrecursors(self):
+        return [type('P', (), {'getMZ': lambda self: self})(self._precursor_mz)]
+
+DataSet = [
+    MockSpectrum(2, 145.2, peaks=[[300.12, 5e4], [300.14, 2e4]], precursor_mz=300.13),
+    MockSpectrum(1, 145.4, peaks=[[300.11, 1.5e5], [300.13, 9e4]])
+]
+```
+
+## Key operations
+- Iterated by [`AllMS2Data`](../Functions/AllMS2Data.md) to stream every spectrum and build [`SummMS2`](./SummMS2.md).
+- Accessed indirectly through [`MS1IDVec`](./MS1IDVec.md) and [`closest_ms1_spec`](../Functions/closest_ms1_spec.md) when MS1 scans are needed for chromatographic refinement.
+- Serves as the source for extracting raw peaks (`get_peaks()`), precursor metadata (`getPrecursors()`), and retention time stamps.
+
+## Parameters
+- `level (int)`: 1 for MS1 chromatograms, 2 for MS2 spectra.
+- `rt (float, seconds)`: chromatographic time of the scan.
+- `peaks (array-like)`: Nx2 array `[m/z, intensity]` representing the profile data.
+- `precursor_mz (float, Da)`: available for MS2 scans and used to filter by m/z.
+
+## Input
+- Consumed directly by [`AllMS2Data`](../Functions/AllMS2Data.md) and [`ms2_features_stats`](../Functions/ms2_features_stats.md) to obtain spectral information.
+
+## Output
+- Not produced directly; functions output tables such as [`SummMS2`](./SummMS2.md) or [`MS2_Features`](./MS2_Features.md).
+
+## Functions
+- [`AllMS2Data`](../Functions/AllMS2Data.md) iterates through the spectra to compile MS2 summaries.
+- [`ms2_features_stats`](../Functions/ms2_features_stats.md) extracts MS1 peak windows using `DataSet` indices stored in [`MS1IDVec`](./MS1IDVec.md).
+
+## Called by
+- Any workflow entry point that loads raw data (e.g., notebooks calling `MS_L_IDs` or `feat_ms2_Gauss`).
+
+## Example table
+
+| spectrum_id | MS level | RT (s) | precursor_mz (Da) | N peaks |
+| --- | --- | --- | --- | --- |
+| 1024 | 2 | 145.2 | 300.13 | 2 |
+| 1025 | 1 | 145.4 | – | 2 |
+
+Each row summarizes an element of `DataSet`, emphasizing the metadata needed downstream.

--- a/documentation/Variables/MS1IDVec.md
+++ b/documentation/Variables/MS1IDVec.md
@@ -1,0 +1,51 @@
+---
+title: MS1IDVec
+kind: table
+source: Variables/MS1IDVec
+last_updated: 2025-02-14
+---
+
+## Description
+`MS1IDVec` maps MS1 scan indices to their retention times. It ensures MS2 detections can pull the correct MS1 chromatographic windows for Gaussian fitting. Each row is `[MS1_scan_id, RT_(s)]` and optionally includes additional metadata (e.g., TIC) appended by helper functions. Without this mapping, [`closest_ms1_spec`](../Functions/closest_ms1_spec.md) could not locate nearby MS1 scans for [`ms2_features_stats`](../Functions/ms2_features_stats.md).
+
+## Code
+```python
+MS1IDVec = np.array([
+    [10020, 244.8],
+    [10021, 245.1],
+    [10022, 245.4]
+])
+```
+
+## Key operations
+- Filtered by scan index and RT to ensure only MS1 events preceding a given MS2 scan are considered.
+- Enables RT proximity calculations via `RT - MS1IDVec[:,1]` inside [`closest_ms1_spec`](../Functions/closest_ms1_spec.md).
+- Serves as the backbone for chromatogram reconstruction in functions like `RetrieveChromatogram` (not yet documented).
+
+## Parameters / columns
+1. `MS1_scan_id`: integer index referencing `DataSet`.
+2. `RT_(s)`: chromatographic time of the MS1 scan.
+
+## Input
+- Produced by helper functions such as `MS_L_IDs` when parsing Thermo RAW files.
+
+## Output
+- Consumed by [`ms2_features_stats`](../Functions/ms2_features_stats.md), [`feat_ms2_Gauss`](../Functions/feat_ms2_Gauss.md), and chromatographic refinement utilities.
+
+## Functions
+- [`closest_ms1_spec`](../Functions/closest_ms1_spec.md)
+- [`ms2_features_stats`](../Functions/ms2_features_stats.md)
+- [`feat_ms2_Gauss`](../Functions/feat_ms2_Gauss.md)
+
+## Called by
+- Notebook pipelines and chromatogram modules needing MS1 scan context.
+
+## Example table
+
+| MS1_scan_id | RT_(s) |
+| --- | --- |
+| 10020 | 244.8 |
+| 10021 | 245.1 |
+| 10022 | 245.4 |
+
+This vector ensures MS2 events can anchor themselves to nearby MS1 scans.

--- a/documentation/Variables/MS2_Features.md
+++ b/documentation/Variables/MS2_Features.md
@@ -1,0 +1,63 @@
+---
+title: MS2_Features
+kind: table
+source: Variables/MS2_Features
+last_updated: 2025-02-14
+---
+
+## Description
+`MS2_Features` is the Gaussian-refined feature catalog returned by [`feat_ms2_Gauss`](../Functions/feat_ms2_Gauss.md). Each row ties an MS2 event to its MS1-derived centroid, uncertainty, and chromatographic umbrella. The table feeds downstream alignment (`Features_ms2_SamplesAligment`) and filtering routines.
+
+## Code
+```python
+MS2_Features = np.array([
+    [18240, 10021, 245.6, 300.123401, 1.5e-03, 8.2e05, 0.997, 28,
+     1.2e-04, 0.40, 299.118, 301.129, 240.1, 248.3, 3, 7021]
+])
+```
+
+## Key operations
+- Columns 0–1 trace provenance: MS2 scan ID and the selected MS1 scan ID.
+- Columns 3–6 hold Gaussian fit results (m/z, standard deviation, integrated intensity, r²) computed by [`ms2_features_stats`](../Functions/ms2_features_stats.md).
+- Columns 8–9 provide absolute and ppm confidence intervals derived from Student’s t-statistic.
+- Columns 12–15 carry chromatographic umbrella metadata inherited from [`SummMS2`](./SummMS2.md).
+
+## Parameters / columns
+1. `ms2_id`: raw MS2 scan index (`MS2_Fullsignal_id`).
+2. `ms1_id`: MS1 scan chosen via [`closest_ms1_spec`](../Functions/closest_ms1_spec.md).
+3. `RT_(s)`: RT of the MS2 detection.
+4. `mz_(Da)`: Gaussian centroid fitted from MS1 data.
+5. `mz_std_(Da)`: Gaussian standard deviation.
+6. `I_total_(a.u.)`: integrated intensity of the Gaussian.
+7. `Gauss_r2`: coefficient of determination between the model and observed MS1 peak.
+8. `N_points`: number of MS1 data points used in the fit.
+9. `CI_(Da)`: confidence interval on m/z in Daltons.
+10. `CI_(ppm)`: same interval expressed in ppm.
+11. `min_mz_(Da)`: lower bound of the integration window.
+12. `max_mz_(Da)`: upper bound of the integration window.
+13. `min_RT_(s)`: start of the chromatographic umbrella.
+14. `max_RT_(s)`: end of the umbrella.
+15. `N_ms2_spec`: number of MS2 spectra merged for this feature.
+16. `spectra_id`: representative MS2 spectrum ID preserved during redundancy removal.
+
+## Input
+- Produced by [`feat_ms2_Gauss`](../Functions/feat_ms2_Gauss.md).
+
+## Output
+- Consumed by [`Cluster_ms2_Features`](../Functions/Cluster_ms2_Features.md) and [`Features_ms2_SamplesAligment`](../Functions/Features_ms2_SamplesAligment.md).
+
+## Functions
+- [`ms2_features_stats`](../Functions/ms2_features_stats.md) populates most columns.
+- [`feat_ms2_Gauss`](../Functions/feat_ms2_Gauss.md) appends umbrella metadata.
+- [`Cluster_ms2_Features`](../Functions/Cluster_ms2_Features.md) converts this array into a pandas DataFrame when clustering is required.
+
+## Called by
+- Workflow notebooks, alignment modules, and downstream filtering functions (e.g., `Samples_NFeatures_Filter`).
+
+## Example table
+
+| ms2_id | ms1_id | RT_(s) | mz_(Da) | mz_std_(Da) | I_total_(a.u.) | Gauss_r2 | N_points | CI_(Da) | CI_(ppm) | min_RT_(s) | max_RT_(s) | N_ms2_spec |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 18240 | 10021 | 245.6 | 300.123401 | 0.0015 | 8.2e05 | 0.997 | 28 | 1.2e-04 | 0.40 | 240.1 | 248.3 | 3 |
+
+Additional columns (`min_mz_(Da)`, `max_mz_(Da)`, `spectra_id`) are omitted here for brevity but present in the actual array.

--- a/documentation/Variables/RawSpectrum.md
+++ b/documentation/Variables/RawSpectrum.md
@@ -1,0 +1,50 @@
+---
+title: RawSpectrum
+kind: variable
+source: Variables/RawSpectrum
+last_updated: 2025-02-14
+---
+
+## Description
+`RawSpectrum` is a numpy array with columns `[m/z, intensity]` representing a single Orbitrap MS2 scan. [`ms2_spectrum`](../Functions/ms2_spectrum.md) cleans and iteratively consumes this array to isolate Gaussian fragment peaks that survive intensity and quality filters.
+
+## Code
+```python
+RawSpectrum = np.array([
+    [150.0234, 1.2e4],
+    [150.0250, 8.1e4],
+    [150.0281, 4.5e4]
+])
+```
+
+## Key operations
+- Filtered to remove non-positive intensities before peak search.
+- Passed to [`ms2_peakStats_safe`](../Functions/ms2_peakStats_safe.md) to estimate Gaussian peak properties around each local maximum.
+- After a peak is accepted, the corresponding m/z window is removed so the next iteration can target lower-intensity fragments.
+
+## Parameters
+- Column 0 (`m/z`, Da): high-resolution mass axis.
+- Column 1 (`intensity`, arbitrary units): ion counts or normalized intensity.
+
+## Input
+- Provided to [`ms2_spectrum`](../Functions/ms2_spectrum.md) from raw data loaders or mzML parsing utilities.
+
+## Output
+- Processed into fragment statistics and appended to [`ms2_spectrum`](../Functions/ms2_spectrum.md) results.
+
+## Functions
+- [`ms2_spectrum`](../Functions/ms2_spectrum.md)
+- [`ms2_peakStats_safe`](../Functions/ms2_peakStats_safe.md)
+
+## Called by
+- Any loader producing MS2 spectra (e.g., `AllMS2Data`) before MS2-first feature construction.
+
+## Example table
+
+| m/z (Da) | intensity (a.u.) |
+| --- | --- |
+| 150.0234 | 12,000 |
+| 150.0250 | 81,000 |
+| 150.0281 | 45,000 |
+
+These rows capture the fragment profile before Gaussian modeling.

--- a/documentation/Variables/SummMS2.md
+++ b/documentation/Variables/SummMS2.md
@@ -1,0 +1,59 @@
+---
+title: SummMS2
+kind: table
+source: Variables/SummMS2
+last_updated: 2025-02-14
+---
+
+## Description
+`SummMS2` stores redundancy-resolved MS2 detections. Each row describes a precursor targeted by the instrument, along with RT umbrellas, intensity statistics, and IDs linking back to raw spectra. It is produced by [`AllMS2Data`](../Functions/AllMS2Data.md) when parsing raw vendor files or by [`ms2_SpectralRedundancy`](../Functions/ms2_SpectralRedundancy.md) when consolidating mzML-derived summaries. The table is the launching point for MS2-first feature construction.
+
+## Code
+```python
+SummMS2 = np.array([
+    [300.1234, 245.6, 18240, 1.2e6, 0.34, 240.1, 248.3, 3, 7021],
+    [450.2011, 512.3, 19305, 8.5e5, 0.42, 509.7, 516.8, 2, 7150]
+])
+```
+
+## Key operations
+- Downstream functions (`ms2_features_stats`, `feat_ms2_Gauss`) read `mz`, `RT`, and `MS2_Fullsignal_id` from columns 0–2.
+- Columns 5–7 store chromatographic umbrellas (`min_RT`, `max_RT`, `N_spec`) used to transfer RT context to [`MS2_Features`](./MS2_Features.md) and [`AlignedSamplesDF`](./AlignedSamplesDF.md).
+- Column 8 retains the representative MS2 spectrum ID for provenance when writing logs or exporting spectra.
+
+## Parameters / columns
+1. `mz_(Da)`: Gaussian centroid of the MS2 precursor.
+2. `RT_(s)`: retention time of the MS2 event.
+3. `MS2_Fullsignal_id`: scan index from the raw file.
+4. `TotalInt_(a.u.)`: sum of intensities inside the MS2 spectrum.
+5. `maxInt_frac`: ratio of the most intense fragment to the total intensity.
+6. `min_RT_(s)`: minimum RT observed among redundant spectra.
+7. `max_RT_(s)`: maximum RT among redundant spectra.
+8. `N_ms2_spec`: number of redundant spectra merged.
+9. `ms2_spec_id`: ID of the representative MS2 spectrum kept after clustering.
+
+## Input
+- [`AllMS2Data`](../Functions/AllMS2Data.md) builds this table directly from `DataSet`.
+- [`ms2_SpectralRedundancy`](../Functions/ms2_SpectralRedundancy.md) re-generates `SummMS2` from spreadsheets.
+
+## Output
+- Consumed by [`ms2_features_stats`](../Functions/ms2_features_stats.md) for MS1 refinement.
+- Fed into [`feat_ms2_Gauss`](../Functions/feat_ms2_Gauss.md) to build [`MS2_Features`](./MS2_Features.md).
+
+## Functions
+- [`AllMS2Data`](../Functions/AllMS2Data.md)
+- [`ms2_SpectralRedundancy`](../Functions/ms2_SpectralRedundancy.md)
+- [`ms2_features_stats`](../Functions/ms2_features_stats.md)
+- [`feat_ms2_Gauss`](../Functions/feat_ms2_Gauss.md)
+
+## Called by
+- Workflow notebooks (`feat.-ms2-Gauss.ipynb`) when orchestrating MS2-first extraction.
+
+## Example table
+
+| mz_(Da) | RT_(s) | MS2_Fullsignal_id | TotalInt_(a.u.) | maxInt_frac | min_RT_(s) | max_RT_(s) | N_ms2_spec | ms2_spec_id |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 300.1234 | 245.6 | 18240 | 1.2e6 | 0.34 | 240.1 | 248.3 | 3 | 7021 |
+| 450.2011 | 512.3 | 19305 | 8.5e5 | 0.42 | 509.7 | 516.8 | 2 | 7150 |
+
+These columns define each MS2 umbrella’s mass accuracy and redundancy context.


### PR DESCRIPTION
## Summary
- add a dedicated `documentation/` tree with agent instructions, glossary, definitions, index, and improvement plan
- document key functions (extraction, redundancy removal, Gaussian fitting, alignment) with math notes, code, and examples following the new template
- document core tables/variables (SummMS2, MS2_Features, All_FeaturesTable, alignment outputs, DataSet abstractions)

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb903d140833296885462c8da99a8)